### PR TITLE
Create test suites for data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: "Tests"
+name: "Tests the App"
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 on:
@@ -9,7 +9,8 @@ on:
     branches:
       - main
 jobs:
-  build:
+  run_test:
+    name: "Run tests"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: "Tests"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install modules
+      run: npm ci
+    - name: Run unit tests
+      run: npm run test
+    - name: Run e2e tests
+      run: npm run test:e2e

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: "Tests"
+env:
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
 on:
   push:
     branches:

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": "./",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
@@ -86,6 +86,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^~/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/prisma/helper.ts
+++ b/prisma/helper.ts
@@ -12,22 +12,22 @@ export const isVillage = (area: Areas): area is Village =>
   'district_code' in area;
 
 /**
- * Parse CSV from local file.
+ * Parse CSV from local file asynchronously.
  *
  * @param path Path to the CSV file.
- * @param onComplete The callback function that will be called when the parsing is complete.
  * @param config The configuration for the parser.
  */
 export const parseCsvFromLocal = <T = any>(
   path: string,
-  onComplete?: (result: Papa.ParseResult<T>) => void,
-  config?: Omit<Papa.ParseLocalConfig<T, Papa.LocalFile>, 'complete'>,
-) => {
+  config?: Omit<Papa.ParseLocalConfig<T, Papa.LocalFile>, 'complete' | 'error'>,
+): Promise<Papa.ParseResult<T>> => {
   const sourceFile = createReadStream(path);
 
-  Papa.parse<T>(sourceFile, {
-    header: true,
-    complete: onComplete,
-    ...config,
+  return new Promise<Papa.ParseResult<T>>((resolve, reject) => {
+    Papa.parse<T>(sourceFile, {
+      ...config,
+      complete: resolve,
+      error: reject,
+    });
   });
 };

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,11 +2,11 @@ import { PrismaClient } from '@prisma/client';
 import { join } from 'path';
 import { isDistrict, isRegency, isVillage, parseCsvFromLocal } from './helper';
 import {
-  Areas,
   AreaByCollection,
+  Areas,
   Collection,
-  Regency,
   District,
+  Regency,
   Village,
 } from './types';
 
@@ -65,16 +65,17 @@ const deleteAreaData = async (collection: Collection) => {
   return res;
 };
 
-const insertAreaData = <T extends Collection>(collection: T) => {
+const insertAreaData = async <T extends Collection>(collection: T) => {
+  console.time(`insert-${collection}`);
+
   const filePath = join(__dirname, `../data/${collection}.csv`);
-
-  parseCsvFromLocal<AreaByCollection<T>>(filePath, async (result) => {
-    console.time(`insert-${collection}`);
-    const res = await insertData(result.data);
-
-    console.timeEnd(`insert-${collection}`);
-    return res;
+  const parsed = await parseCsvFromLocal<AreaByCollection<T>>(filePath, {
+    header: true,
   });
+  const res = await insertData(parsed.data);
+
+  console.timeEnd(`insert-${collection}`);
+  return res;
 };
 
 async function main() {
@@ -83,10 +84,10 @@ async function main() {
   await deleteAreaData('regencies');
   await deleteAreaData('provinces');
 
-  insertAreaData('provinces');
-  insertAreaData('regencies');
-  insertAreaData('districts');
-  insertAreaData('villages');
+  await insertAreaData('provinces');
+  await insertAreaData('regencies');
+  await insertAreaData('districts');
+  await insertAreaData('villages');
 }
 
 main()

--- a/src/district/district.controller.spec.ts
+++ b/src/district/district.controller.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DistrictController } from './district.controller';
+import { HelperModule } from 'src/helper/helper.module';
+import { PrismaService } from 'src/prisma.service';
+import { DistrictService } from './district.service';
 
 describe('DistrictController', () => {
   let controller: DistrictController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HelperModule],
       controllers: [DistrictController],
+      providers: [DistrictService, PrismaService],
     }).compile();
 
     controller = module.get<DistrictController>(DistrictController);

--- a/src/district/district.controller.spec.ts
+++ b/src/district/district.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { DistrictController } from './district.controller';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
 import { DistrictService } from './district.service';
 
 describe('DistrictController', () => {

--- a/src/district/district.dto.ts
+++ b/src/district/district.dto.ts
@@ -4,8 +4,8 @@ import {
   IsOptional,
   Length,
 } from 'class-validator';
-import { EqualsAny } from 'src/common/decorator/EqualsAny';
-import { IsNotSymbol } from 'src/common/decorator/IsNotSymbol';
+import { EqualsAny } from '~/src/common/decorator/EqualsAny';
+import { IsNotSymbol } from '~/src/common/decorator/IsNotSymbol';
 
 export class DistrictFindQueries {
   @IsNotEmpty()

--- a/src/district/district.module.ts
+++ b/src/district/district.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { DistrictController } from './district.controller';
 import { DistrictService } from './district.service';
 

--- a/src/district/district.service.spec.ts
+++ b/src/district/district.service.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { DistrictService } from './district.service';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { DistrictController } from './district.controller';
+import { DistrictService } from './district.service';
 
 describe('DistrictService', () => {
   let service: DistrictService;

--- a/src/district/district.service.spec.ts
+++ b/src/district/district.service.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DistrictService } from './district.service';
+import { HelperModule } from 'src/helper/helper.module';
+import { PrismaService } from 'src/prisma.service';
+import { DistrictController } from './district.controller';
 
 describe('DistrictService', () => {
   let service: DistrictService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DistrictService],
+      imports: [HelperModule],
+      controllers: [DistrictController],
+      providers: [DistrictService, PrismaService],
     }).compile();
 
     service = module.get<DistrictService>(DistrictService);

--- a/src/district/district.service.ts
+++ b/src/district/district.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { District, Village } from '@prisma/client';
-import { SortHelper, SortOptions } from 'src/helper/sort.helper';
-import { PrismaService } from 'src/prisma.service';
+import { SortHelper, SortOptions } from '~/src/helper/sort.helper';
+import { PrismaService } from '~/src/prisma.service';
 
 @Injectable()
 export class DistrictService {

--- a/src/province/province.controller.spec.ts
+++ b/src/province/province.controller.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProvinceController } from './province.controller';
+import { HelperModule } from 'src/helper/helper.module';
+import { PrismaService } from 'src/prisma.service';
+import { ProvinceService } from './province.service';
 
 describe('ProvinceController', () => {
   let controller: ProvinceController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HelperModule],
       controllers: [ProvinceController],
+      providers: [PrismaService, ProvinceService],
     }).compile();
 
     controller = module.get<ProvinceController>(ProvinceController);

--- a/src/province/province.controller.spec.ts
+++ b/src/province/province.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { ProvinceController } from './province.controller';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
 import { ProvinceService } from './province.service';
 
 describe('ProvinceController', () => {

--- a/src/province/province.dto.ts
+++ b/src/province/province.dto.ts
@@ -4,8 +4,8 @@ import {
   IsOptional,
   Length,
 } from 'class-validator';
-import { EqualsAny } from 'src/common/decorator/EqualsAny';
-import { IsNotSymbol } from 'src/common/decorator/IsNotSymbol';
+import { EqualsAny } from '~/src/common/decorator/EqualsAny';
+import { IsNotSymbol } from '~/src/common/decorator/IsNotSymbol';
 
 export class ProvinceFindQueries {
   @IsOptional()

--- a/src/province/province.module.ts
+++ b/src/province/province.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { ProvinceController } from './province.controller';
 import { ProvinceService } from './province.service';
 

--- a/src/province/province.service.spec.ts
+++ b/src/province/province.service.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProvinceService } from './province.service';
+import { HelperModule } from 'src/helper/helper.module';
+import { PrismaService } from 'src/prisma.service';
+import { ProvinceController } from './province.controller';
 
 describe('ProvinceService', () => {
   let service: ProvinceService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ProvinceService],
+      imports: [HelperModule],
+      controllers: [ProvinceController],
+      providers: [PrismaService, ProvinceService],
     }).compile();
 
     service = module.get<ProvinceService>(ProvinceService);

--- a/src/province/province.service.spec.ts
+++ b/src/province/province.service.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ProvinceService } from './province.service';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { ProvinceController } from './province.controller';
+import { ProvinceService } from './province.service';
 
 describe('ProvinceService', () => {
   let service: ProvinceService;

--- a/src/province/province.service.ts
+++ b/src/province/province.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Province, Regency } from '@prisma/client';
-import { SortHelper, SortOptions } from 'src/helper/sort.helper';
-import { PrismaService } from 'src/prisma.service';
+import { SortHelper, SortOptions } from '~/src/helper/sort.helper';
+import { PrismaService } from '~/src/prisma.service';
 
 @Injectable()
 export class ProvinceService {

--- a/src/regency/regency.controller.spec.ts
+++ b/src/regency/regency.controller.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RegencyController } from './regency.controller';
+import { HelperModule } from 'src/helper/helper.module';
+import { PrismaService } from 'src/prisma.service';
+import { RegencyService } from './regency.service';
 
 describe('RegencyController', () => {
   let controller: RegencyController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HelperModule],
       controllers: [RegencyController],
+      providers: [PrismaService, RegencyService],
     }).compile();
 
     controller = module.get<RegencyController>(RegencyController);

--- a/src/regency/regency.controller.spec.ts
+++ b/src/regency/regency.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { RegencyController } from './regency.controller';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
 import { RegencyService } from './regency.service';
 
 describe('RegencyController', () => {

--- a/src/regency/regency.dto.ts
+++ b/src/regency/regency.dto.ts
@@ -4,8 +4,8 @@ import {
   IsOptional,
   Length,
 } from 'class-validator';
-import { EqualsAny } from 'src/common/decorator/EqualsAny';
-import { IsNotSymbol } from 'src/common/decorator/IsNotSymbol';
+import { EqualsAny } from '~/src/common/decorator/EqualsAny';
+import { IsNotSymbol } from '~/src/common/decorator/IsNotSymbol';
 
 export class RegencyFindQueries {
   @IsNotEmpty()

--- a/src/regency/regency.module.ts
+++ b/src/regency/regency.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { RegencyController } from './regency.controller';
 import { RegencyService } from './regency.service';
 

--- a/src/regency/regency.service.spec.ts
+++ b/src/regency/regency.service.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { RegencyService } from './regency.service';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { RegencyController } from './regency.controller';
+import { RegencyService } from './regency.service';
 
 describe('RegencyService', () => {
   let service: RegencyService;

--- a/src/regency/regency.service.spec.ts
+++ b/src/regency/regency.service.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RegencyService } from './regency.service';
+import { HelperModule } from 'src/helper/helper.module';
+import { PrismaService } from 'src/prisma.service';
+import { RegencyController } from './regency.controller';
 
 describe('RegencyService', () => {
   let service: RegencyService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RegencyService],
+      imports: [HelperModule],
+      controllers: [RegencyController],
+      providers: [PrismaService, RegencyService],
     }).compile();
 
     service = module.get<RegencyService>(RegencyService);

--- a/src/regency/regency.service.ts
+++ b/src/regency/regency.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { District, Regency } from '@prisma/client';
-import { SortHelper, SortOptions } from 'src/helper/sort.helper';
-import { PrismaService } from 'src/prisma.service';
+import { SortHelper, SortOptions } from '~/src/helper/sort.helper';
+import { PrismaService } from '~/src/prisma.service';
 
 @Injectable()
 export class RegencyService {

--- a/src/village/village.controller.spec.ts
+++ b/src/village/village.controller.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { VillageController } from './village.controller';
+import { HelperModule } from 'src/helper/helper.module';
+import { PrismaService } from 'src/prisma.service';
+import { VillageService } from './village.service';
 
 describe('VillageController', () => {
   let controller: VillageController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HelperModule],
       controllers: [VillageController],
+      providers: [PrismaService, VillageService],
     }).compile();
 
     controller = module.get<VillageController>(VillageController);

--- a/src/village/village.controller.spec.ts
+++ b/src/village/village.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { VillageController } from './village.controller';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
 import { VillageService } from './village.service';
 
 describe('VillageController', () => {

--- a/src/village/village.dto.ts
+++ b/src/village/village.dto.ts
@@ -1,11 +1,11 @@
 import {
-  IsNotEmpty,
-  Length,
-  IsOptional,
   IsAlphanumeric,
+  IsNotEmpty,
+  IsOptional,
+  Length,
 } from 'class-validator';
-import { EqualsAny } from 'src/common/decorator/EqualsAny';
-import { IsNotSymbol } from 'src/common/decorator/IsNotSymbol';
+import { EqualsAny } from '~/src/common/decorator/EqualsAny';
+import { IsNotSymbol } from '~/src/common/decorator/IsNotSymbol';
 
 export class VillageFindQueries {
   @IsNotEmpty()

--- a/src/village/village.module.ts
+++ b/src/village/village.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { VillageController } from './village.controller';
 import { VillageService } from './village.service';
 

--- a/src/village/village.service.spec.ts
+++ b/src/village/village.service.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { VillageService } from './village.service';
-import { HelperModule } from 'src/helper/helper.module';
-import { PrismaService } from 'src/prisma.service';
+import { HelperModule } from '~/src/helper/helper.module';
+import { PrismaService } from '~/src/prisma.service';
 import { VillageController } from './village.controller';
+import { VillageService } from './village.service';
 
 describe('VillageService', () => {
   let service: VillageService;

--- a/src/village/village.service.spec.ts
+++ b/src/village/village.service.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { VillageService } from './village.service';
+import { HelperModule } from 'src/helper/helper.module';
+import { PrismaService } from 'src/prisma.service';
+import { VillageController } from './village.controller';
 
 describe('VillageService', () => {
   let service: VillageService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VillageService],
+      imports: [HelperModule],
+      controllers: [VillageController],
+      providers: [PrismaService, VillageService],
     }).compile();
 
     service = module.get<VillageService>(VillageService);

--- a/src/village/village.service.ts
+++ b/src/village/village.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { SortHelper, SortOptions } from 'src/helper/sort.helper';
-import { PrismaService } from 'src/prisma.service';
 import { Village } from '@prisma/client';
+import { SortHelper, SortOptions } from '~/src/helper/sort.helper';
+import { PrismaService } from '~/src/prisma.service';
 
 @Injectable()
 export class VillageService {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { AppModule } from '~/src/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,24 +1,32 @@
-import { INestApplication } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from '~/src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication;
+  let app: NestFastifyApplication;
 
   beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
+    const moduleRef: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
+    app = moduleRef.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+
     await app.init();
+    await app.getHttpAdapter().getInstance().ready();
   });
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+    return request(app.getHttpServer()).get('/').expect(200).expect({
+      message: 'Welcome to Indonesia Area API.',
+      version: '1.0.0',
+      docs: '/docs',
+    });
   });
 });

--- a/test/data.e2e-spec.ts
+++ b/test/data.e2e-spec.ts
@@ -1,0 +1,174 @@
+import { join } from 'path';
+import { parseCsvFromLocal } from '~/prisma/helper';
+import {
+  AreaByCollection,
+  Collection,
+  District,
+  Province,
+  Regency,
+  Village,
+} from '~/prisma/types';
+
+/**
+ * Get data from local CSV file.
+ *
+ * @param collection The collection name
+ */
+const getData = async <C extends Collection>(
+  collection: C,
+): Promise<AreaByCollection<C>[]> => {
+  const filePath = join(__dirname, `../data/${collection}.csv`);
+  const result = await parseCsvFromLocal<AreaByCollection<C>>(filePath, {
+    header: true,
+  });
+
+  return result.data;
+};
+
+/**
+ * Check if a string is a number and has a specific length.
+ *
+ * @param value The string to be checked
+ * @param digits The length of the string
+ */
+const isStrNumber = (value: string, digits?: number): value is string =>
+  /^\d+$/.test(value) && (!digits || value.length === digits);
+
+// Test provinces data
+let provinces: Province[];
+
+describe('provinces data', () => {
+  beforeAll(async () => {
+    provinces = await getData('provinces');
+  });
+
+  it('should be defined', () => {
+    expect(provinces).toBeDefined();
+  });
+
+  it('should have valid code (2 digits number)', () => {
+    const ids = provinces.map((province) => province.code);
+    const validIds = ids.filter((id) => isStrNumber(id, 2));
+
+    expect(ids).toEqual(validIds);
+    expect(validIds.length).toBeGreaterThan(0);
+  });
+
+  it('should have unique code', () => {
+    const ids = provinces.map((province) => province.code);
+    const uniqueIds = [...new Set(ids)];
+
+    expect(ids).toEqual(uniqueIds);
+  });
+});
+
+// Test regencies data
+let regencies: Regency[];
+
+describe('regencies data', () => {
+  beforeAll(async () => {
+    regencies = await getData('regencies');
+  });
+
+  it('should be defined', () => {
+    expect(regencies).toBeDefined();
+  });
+
+  it('should have valid code (4 digits number)', () => {
+    const ids = regencies.map((regency) => regency.code);
+    const validIds = ids.filter((id) => isStrNumber(id, 4));
+
+    expect(ids).toEqual(validIds);
+    expect(validIds.length).toBeGreaterThan(0);
+  });
+
+  it('should have unique code', () => {
+    const ids = regencies.map((regency) => regency.code);
+    const uniqueIds = [...new Set(ids)];
+
+    expect(ids).toEqual(uniqueIds);
+  });
+
+  it('should have valid province code', () => {
+    const provinceCodes = provinces.map((province) => province.code).sort();
+    const uniqueRegencyProvinceCodes = [
+      ...new Set(regencies.map((regency) => regency.province_code)),
+    ].sort();
+
+    expect(uniqueRegencyProvinceCodes).toEqual(provinceCodes);
+  });
+});
+
+// Test districts data
+let districts: District[];
+
+describe('districts data', () => {
+  beforeAll(async () => {
+    districts = await getData('districts');
+  });
+
+  it('should be defined', () => {
+    expect(districts).toBeDefined();
+  });
+
+  it('should have valid code (6 digits number)', () => {
+    const ids = districts.map((district) => district.code);
+    const validIds = ids.filter((id) => isStrNumber(id, 6));
+
+    expect(ids).toEqual(validIds);
+    expect(validIds.length).toBeGreaterThan(0);
+  });
+
+  it('should have unique code', () => {
+    const ids = districts.map((district) => district.code);
+    const uniqueIds = [...new Set(ids)];
+
+    expect(ids).toEqual(uniqueIds);
+  });
+
+  it('should have valid regency code', () => {
+    const regencyCodes = regencies.map((regency) => regency.code).sort();
+    const uniqueDistrictRegencyCodes = [
+      ...new Set(districts.map((district) => district.regency_code)),
+    ].sort();
+
+    expect(uniqueDistrictRegencyCodes).toEqual(regencyCodes);
+  });
+});
+
+// Test villages data\
+let villages: Village[];
+
+describe('villages data', () => {
+  beforeAll(async () => {
+    villages = await getData('villages');
+  });
+
+  it('should be defined', () => {
+    expect(villages).toBeDefined();
+  });
+
+  it('should have valid code (10 digits number)', () => {
+    const ids = villages.map((village) => village.code);
+    const validIds = ids.filter((id) => isStrNumber(id, 10));
+
+    expect(ids).toEqual(validIds);
+    expect(validIds.length).toBeGreaterThan(0);
+  });
+
+  it('should have unique code', () => {
+    const ids = villages.map((village) => village.code);
+    const uniqueIds = [...new Set(ids)];
+
+    expect(ids).toEqual(uniqueIds);
+  });
+
+  it('should have valid district code', () => {
+    const districtCodes = districts.map((district) => district.code).sort();
+    const uniqueVillageDistrictCodes = [
+      ...new Set(villages.map((village) => village.district_code)),
+    ].sort();
+
+    expect(uniqueVillageDistrictCodes).toEqual(districtCodes);
+  });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^~/(.*)$": "<rootDir>/../$1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "paths": {
+      "~/*": ["./*"],
+    },
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put "x" to check

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [x] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using "x"

- [ ] Bug fix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Data change
- [ ] *..... (describe the other type)*

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

There are no test for the [data](https://github.com/fityannugroho/idn-area/tree/main/data), so that `npm run db:seed` may be return some errors.

## What is the new behavior?

The main goal of this PR is to create the test suits to validate the [data](https://github.com/fityannugroho/idn-area/tree/main/data).

To achieve this goal, this changes below is required:

- Fix initial unit tests (1f285f5dae92cb53bec07b3840143b71b66d824e)

  TODO: need to write the test for API endpoints later.

- Refactor the import path that start from `src/` (b0d885a5e018edbbfaa7807d742cde2d6fec9403, 3d8cca4417c9e6de06bf043e0a6d1ed80d0bcc8f)

  Jest can't recognize the `src/` path without [`moduleNameMapper`](https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring) configuration. Therefore, to simplify the `moduleNameMapper` settings, we set [tsconfig `paths`](https://www.typescriptlang.org/tsconfig#paths) for `~/*` and change all imports that use `src/` path.

- Make `parseCsvFromLocal` to work asynchronously (f41e793cbfa5805146f3793ee626df4cdcccc6bc)

  Old sync `parseCsvFromLocal` doesn't suitable for Jest test.

- Create test suites (d3e7353233b1dcb79bcf68c1dd0021a475dbc59f)
- Create CI to run test suites on push or PR to `main` branch (14636db1790d55e88dc9bace93991918a518d014)

## Other information

> For PR that includes `data change`, you MUST put **the official link to the related government regulations,** so we can review and make sure the data change is legally valid.

None
