### PR TITLE
Add `meta` property in data endpoints response

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,14 +1,10 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, HttpStatus } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
-import { UnwrapResponse } from './common/decorator/unwrap-response.decorator';
-import { ResponseMessage } from './common/decorator/response-message.decorator';
 
 @ApiTags('Home')
 @Controller()
 export class AppController {
   @Get()
-  @UnwrapResponse()
-  @ResponseMessage('Welcome to Indonesia Area API.')
   @ApiOkResponse({
     schema: {
       type: 'object',
@@ -25,6 +21,8 @@ export class AppController {
   })
   async index() {
     return {
+      statusCode: HttpStatus.OK,
+      message: 'Welcome to Indonesia Area API.',
       version: process.env.npm_package_version,
       docs: '/docs',
     };

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule, seconds } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { DistrictModule } from './district/district.module';
@@ -8,7 +8,6 @@ import { IslandModule } from './island/island.module';
 import { ProvinceModule } from './province/province.module';
 import { RegencyModule } from './regency/regency.module';
 import { VillageModule } from './village/village.module';
-import { TransformInterceptor } from './common/interceptor/transform.interceptor';
 
 @Module({
   imports: [
@@ -35,10 +34,6 @@ import { TransformInterceptor } from './common/interceptor/transform.interceptor
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,
-    },
-    {
-      provide: APP_INTERCEPTOR,
-      useClass: TransformInterceptor,
     },
   ],
 })

--- a/src/common/decorator/api-data-response.decorator.ts
+++ b/src/common/decorator/api-data-response.decorator.ts
@@ -1,16 +1,49 @@
-import { Type, applyDecorators } from '@nestjs/common';
+import {
+  SetMetadata,
+  Type,
+  UseInterceptors,
+  applyDecorators,
+} from '@nestjs/common';
 import { ApiExtraModels, ApiOkResponse, getSchemaPath } from '@nestjs/swagger';
+import { TransformInterceptor } from '../interceptor/transform.interceptor';
 
 interface Options<Model extends Type<any>> {
+  /**
+   * The model that will be used in the response.
+   */
   model: Model;
+  /**
+   * Indicates if the response is an array or not.
+   */
   multiple?: boolean;
+  /**
+   * The description of the response.
+   * This will be used in the swagger documentation.
+   */
   description?: string;
+  /**
+   * The message that will be returned in the response.
+   *
+   * @default 'OK'
+   */
+  message?: string | string[];
 }
 
+/**
+ * This decorator will wrap the response into `data` property and add these properties:
+ * - `statusCode` (number)
+ * - `message` (string)
+ * - `total` (number) (only if `multiple` is true)
+ *
+ * This decorator will also add `ApiExtraModels` and `ApiOkResponse` decorator
+ * to generate the swagger documentation.
+ */
 export const ApiDataResponse = <Model extends Type<any>>(
   options: Options<Model>,
 ) => {
   return applyDecorators(
+    SetMetadata('response_message', options.message),
+    UseInterceptors(TransformInterceptor),
     ApiExtraModels(options.model),
     ApiOkResponse({
       description: options?.description,

--- a/src/common/decorator/api-data-response.decorator.ts
+++ b/src/common/decorator/api-data-response.decorator.ts
@@ -30,10 +30,17 @@ interface Options<Model extends Type<any>> {
 }
 
 /**
- * This decorator will wrap the response into `data` property and add these properties:
+ * This decorator will wrap the response into `data` property.
+ *
+ * To add additional metadata, your method must return an object with `data` and `meta` property
+ * (see the `WrappedData` interface)
+ *
+ * The transformed response will have the following properties:
  * - `statusCode` (number)
  * - `message` (string)
- * - `total` (number) (only if `multiple` is true)
+ * - `data` (object or array)
+ * - `meta` (object, optional)
+ *    - `total` (number, if the `data` is an array)
  *
  * This decorator will also add `ApiExtraModels` and `ApiOkResponse` decorator
  * to generate the swagger documentation.
@@ -61,9 +68,15 @@ export const ApiDataResponse = <Model extends Type<any>>(
                 type: 'object',
                 $ref: getSchemaPath(options.model),
               },
-          total: options.multiple
-            ? { type: 'number', example: 1, nullable: true }
-            : undefined,
+          meta: {
+            type: 'object',
+            nullable: options.multiple ? undefined : true,
+            properties: {
+              total: options.multiple
+                ? { type: 'number', example: 1 }
+                : undefined,
+            },
+          },
         },
       },
     }),

--- a/src/common/decorator/response-message.decorator.ts
+++ b/src/common/decorator/response-message.decorator.ts
@@ -1,4 +1,0 @@
-import { SetMetadata } from '@nestjs/common';
-
-export const ResponseMessage = (message: string | string[]) =>
-  SetMetadata('response_message', message);

--- a/src/common/decorator/unwrap-response.decorator.ts
+++ b/src/common/decorator/unwrap-response.decorator.ts
@@ -1,9 +1,0 @@
-import { SetMetadata } from '@nestjs/common';
-
-/**
- * Decorator to unwrap response data.
- *
- * Without this decorator, the response will be wrapped in the `data` field.
- */
-export const UnwrapResponse = (value = true) =>
-  SetMetadata('unwrap_response', value);

--- a/src/common/interceptor/transform.interceptor.ts
+++ b/src/common/interceptor/transform.interceptor.ts
@@ -9,52 +9,84 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { isDBProvider } from '../utils/db/provider';
 
-export interface TransformedResponse<T> {
+export interface WrappedData<
+  Data,
+  Meta extends Record<string, unknown> = Record<string, unknown>,
+> {
+  data: Data;
+  meta?: Meta;
+}
+
+export interface TransformedResponse<
+  Data,
+  Meta = WrappedData<unknown>['meta'],
+> {
   statusCode: number;
   message: string | string[];
-  data: T;
-  total?: number;
+  data: Data;
+  meta: Data extends any[] ? { total: number } & Meta : Meta | undefined;
+}
+
+/**
+ * Check if the value contains `data` property.
+ */
+function isDataWrapped<T>(value: any): value is WrappedData<T> {
+  return (
+    'data' in value &&
+    (typeof value.data === 'object' || Array.isArray(value.data))
+  );
 }
 
 @Injectable()
-export class TransformInterceptor<T>
-  implements NestInterceptor<T, TransformedResponse<T>>
+export class TransformInterceptor<T, R extends TransformedResponse<T>>
+  implements NestInterceptor<T, R>
 {
   constructor(private reflector: Reflector) {}
 
-  intercept(
-    context: ExecutionContext,
-    next: CallHandler,
-  ): Observable<TransformedResponse<T>> {
+  protected transformValue(val: any): WrappedData<T> {
+    const res: WrappedData<T> = isDataWrapped<T>(val) ? val : { data: val };
+
+    // Remove the `id` property from the data if the database provider is MongoDB.
+    if (isDBProvider('mongodb')) {
+      if (Array.isArray(res.data)) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        res.data = res.data.map(({ id, ...item }) => ({
+          id: undefined,
+          ...item,
+        })) as T;
+      } else {
+        delete (res.data as { id: string }).id;
+      }
+    }
+
+    // Add the `total` property to the meta if the data is an array.
+    if (Array.isArray(res.data)) {
+      res.meta = {
+        ...(res.meta ?? {}),
+        total: res.data.length,
+      };
+    }
+
+    return res;
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler<T>): Observable<R> {
     const resMsg =
       this.reflector.get<string | string[]>(
         'response_message',
         context.getHandler(),
       ) || 'OK';
 
-    const unwrapResponse = this.reflector.get<boolean>(
-      'unwrap_response',
-      context.getHandler(),
-    );
-
     return next.handle().pipe(
-      map((data) => {
-        // Remove the `id` property from the data if the database provider is MongoDB.
-        if (isDBProvider('mongodb')) {
-          if (Array.isArray(data)) {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            data = data.map(({ id, ...item }) => ({ id: undefined, ...item }));
-          } else {
-            delete data.id;
-          }
-        }
+      map((res) => {
+        const { data, meta } = this.transformValue(res);
 
         return {
           statusCode: context.switchToHttp().getResponse().statusCode,
           message: resMsg,
-          ...(unwrapResponse && !Array.isArray(data) ? data : { data }),
-          total: Array.isArray(data) ? data.length : undefined,
-        };
+          data,
+          meta,
+        } as R;
       }),
     );
   }

--- a/src/common/interceptor/transform.interceptor.ts
+++ b/src/common/interceptor/transform.interceptor.ts
@@ -59,14 +59,6 @@ export class TransformInterceptor<T, R extends TransformedResponse<T>>
       }
     }
 
-    // Add the `total` property to the meta if the data is an array.
-    if (Array.isArray(res.data)) {
-      res.meta = {
-        ...(res.meta ?? {}),
-        total: res.data.length,
-      };
-    }
-
     return res;
   }
 
@@ -85,7 +77,10 @@ export class TransformInterceptor<T, R extends TransformedResponse<T>>
           statusCode: context.switchToHttp().getResponse().statusCode,
           message: resMsg,
           data,
-          meta,
+          // Add the `total` property to the meta if the data is an array.
+          meta: Array.isArray(data)
+            ? { total: data.length, ...(meta ?? {}) }
+            : meta,
         } as R;
       }),
     );

--- a/src/common/interceptor/transform.interceptor.ts
+++ b/src/common/interceptor/transform.interceptor.ts
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { isDBProvider } from '../utils/db/provider';
 
-export interface SuccessfulResponse<T> {
+export interface TransformedResponse<T> {
   statusCode: number;
   message: string | string[];
   data: T;
@@ -18,14 +18,14 @@ export interface SuccessfulResponse<T> {
 
 @Injectable()
 export class TransformInterceptor<T>
-  implements NestInterceptor<T, SuccessfulResponse<T>>
+  implements NestInterceptor<T, TransformedResponse<T>>
 {
   constructor(private reflector: Reflector) {}
 
   intercept(
     context: ExecutionContext,
     next: CallHandler,
-  ): Observable<SuccessfulResponse<T>> {
+  ): Observable<TransformedResponse<T>> {
     const resMsg =
       this.reflector.get<string | string[]>(
         'response_message',

--- a/src/district/district.controller.spec.ts
+++ b/src/district/district.controller.spec.ts
@@ -1,5 +1,6 @@
 import { getValues, sortArray } from '@/common/utils/array';
 import { getDistricts, getVillages } from '@/common/utils/data';
+import { SortOrder } from '@/sort/sort.dto';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { District, Village } from '@prisma/client';
@@ -102,11 +103,14 @@ describe('DistrictController', () => {
       const testDistricts = await controller.find({
         name: testDistrictName,
         sortBy: 'name',
-        sortOrder: 'desc',
+        sortOrder: SortOrder.DESC,
       });
 
       expect(getValues(testDistricts, 'code')).toEqual(
-        getValues(sortArray(filteredDistrictsByName, 'name', 'desc'), 'code'),
+        getValues(
+          sortArray(filteredDistrictsByName, 'name', SortOrder.DESC),
+          'code',
+        ),
       );
     });
   });
@@ -180,11 +184,11 @@ describe('DistrictController', () => {
     it('should return all villages in the matching district sorted by name descending', async () => {
       const testVillages = await controller.findVillages(
         { code: testDistrictCode },
-        { sortBy: 'name', sortOrder: 'desc' },
+        { sortBy: 'name', sortOrder: SortOrder.DESC },
       );
 
       expect(getValues(testVillages, 'code')).toEqual(
-        getValues(sortArray(expectedVillages, 'name', 'desc'), 'code'),
+        getValues(sortArray(expectedVillages, 'name', SortOrder.DESC), 'code'),
       );
     });
   });

--- a/src/island/island.controller.spec.ts
+++ b/src/island/island.controller.spec.ts
@@ -1,5 +1,6 @@
 import { getValues, sortArray } from '@/common/utils/array';
 import { getIslands } from '@/common/utils/data';
+import { SortOrder } from '@/sort/sort.dto';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Island } from '@prisma/client';
@@ -103,11 +104,14 @@ describe('IslandController', () => {
       const testIslands = await controller.find({
         name: testIslandName,
         sortBy: 'name',
-        sortOrder: 'desc',
+        sortOrder: SortOrder.DESC,
       });
 
       expect(getValues(testIslands, 'code')).toEqual(
-        getValues(sortArray(filteredIslandsByName, 'name', 'desc'), 'code'),
+        getValues(
+          sortArray(filteredIslandsByName, 'name', SortOrder.DESC),
+          'code',
+        ),
       );
     });
 
@@ -126,12 +130,12 @@ describe('IslandController', () => {
       const testIslands = await controller.find({
         name: testIslandName,
         sortBy: 'coordinate',
-        sortOrder: 'desc',
+        sortOrder: SortOrder.DESC,
       });
 
       expect(getValues(testIslands, 'code')).toEqual(
         getValues(
-          sortArray(filteredIslandsByName, 'coordinate', 'desc'),
+          sortArray(filteredIslandsByName, 'coordinate', SortOrder.DESC),
           'code',
         ),
       );

--- a/src/province/province.controller.spec.ts
+++ b/src/province/province.controller.spec.ts
@@ -1,5 +1,6 @@
 import { getValues, sortArray } from '@/common/utils/array';
 import { getProvinces, getRegencies } from '@/common/utils/data';
+import { SortOrder } from '@/sort/sort.dto';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Province, Regency } from '@prisma/client';
@@ -55,7 +56,7 @@ describe('ProvinceController', () => {
     it('should return all provinces sorted by name ascending', async () => {
       const testProvinces = await controller.find({
         sortBy: 'name',
-        sortOrder: 'asc',
+        sortOrder: SortOrder.ASC,
       });
 
       expect(getValues(testProvinces, 'code')).toEqual(
@@ -66,7 +67,7 @@ describe('ProvinceController', () => {
     it('should return all provinces sorted by name descending', async () => {
       const testProvinces = await controller.find({
         sortBy: 'name',
-        sortOrder: 'desc',
+        sortOrder: SortOrder.DESC,
       });
 
       expect(getValues(testProvinces, 'code')).toEqual(
@@ -147,7 +148,7 @@ describe('ProvinceController', () => {
     it('should return all regencies in the matching province sorted by name ascending', async () => {
       const testRegencies = await controller.findRegencies(
         { code: testProvCode },
-        { sortBy: 'name', sortOrder: 'asc' },
+        { sortBy: 'name', sortOrder: SortOrder.ASC },
       );
 
       expect(getValues(testRegencies, 'code')).toEqual(
@@ -158,11 +159,11 @@ describe('ProvinceController', () => {
     it('should return all regencies in the matching province sorted by name descending', async () => {
       const testRegencies = await controller.findRegencies(
         { code: testProvCode },
-        { sortBy: 'name', sortOrder: 'desc' },
+        { sortBy: 'name', sortOrder: SortOrder.DESC },
       );
 
       expect(getValues(testRegencies, 'code')).toEqual(
-        getValues(sortArray(expectedRegencies, 'name', 'desc'), 'code'),
+        getValues(sortArray(expectedRegencies, 'name', SortOrder.DESC), 'code'),
       );
     });
   });

--- a/src/regency/regency.controller.spec.ts
+++ b/src/regency/regency.controller.spec.ts
@@ -1,5 +1,6 @@
 import { getValues, sortArray } from '@/common/utils/array';
 import { getDistricts, getIslands, getRegencies } from '@/common/utils/data';
+import { SortOrder } from '@/sort/sort.dto';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { District, Island, Regency } from '@prisma/client';
@@ -104,11 +105,14 @@ describe('RegencyController', () => {
       const testRegencies = await controller.find({
         name: testRegencyName,
         sortBy: 'name',
-        sortOrder: 'desc',
+        sortOrder: SortOrder.DESC,
       });
 
       expect(getValues(testRegencies, 'code')).toEqual(
-        getValues(sortArray(filteredRegenciesByName, 'name', 'desc'), 'code'),
+        getValues(
+          sortArray(filteredRegenciesByName, 'name', SortOrder.DESC),
+          'code',
+        ),
       );
     });
   });
@@ -169,7 +173,7 @@ describe('RegencyController', () => {
     it('should return all districts in the matching regency sorted by name ascending', async () => {
       const testDistricts = await controller.findDistricts(
         { code: testRegencyCode },
-        { sortBy: 'name', sortOrder: 'asc' },
+        { sortBy: 'name', sortOrder: SortOrder.ASC },
       );
 
       expect(getValues(testDistricts, 'code')).toEqual(
@@ -180,11 +184,11 @@ describe('RegencyController', () => {
     it('should return all districts in the matching regency sorted by name descending', async () => {
       const testDistricts = await controller.findDistricts(
         { code: testRegencyCode },
-        { sortBy: 'name', sortOrder: 'desc' },
+        { sortBy: 'name', sortOrder: SortOrder.DESC },
       );
 
       expect(getValues(testDistricts, 'code')).toEqual(
-        getValues(sortArray(expectedDistricts, 'name', 'desc'), 'code'),
+        getValues(sortArray(expectedDistricts, 'name', SortOrder.DESC), 'code'),
       );
     });
   });
@@ -231,7 +235,7 @@ describe('RegencyController', () => {
     it('should return all islands in the matching regency sorted by name ascending', async () => {
       const testIslands = await controller.findIslands(
         { code: testRegencyCode },
-        { sortBy: 'name', sortOrder: 'asc' },
+        { sortBy: 'name', sortOrder: SortOrder.ASC },
       );
 
       expect(getValues(testIslands, 'code')).toEqual(
@@ -242,18 +246,18 @@ describe('RegencyController', () => {
     it('should return all islands in the matching regency sorted by name descending', async () => {
       const testIslands = await controller.findIslands(
         { code: testRegencyCode },
-        { sortBy: 'name', sortOrder: 'desc' },
+        { sortBy: 'name', sortOrder: SortOrder.DESC },
       );
 
       expect(getValues(testIslands, 'code')).toEqual(
-        getValues(sortArray(expectedIslands, 'name', 'desc'), 'code'),
+        getValues(sortArray(expectedIslands, 'name', SortOrder.DESC), 'code'),
       );
     });
 
     it('should return all islands in the matching regency sorted by coordinate ascending', async () => {
       const testIslands = await controller.findIslands(
         { code: testRegencyCode },
-        { sortBy: 'coordinate', sortOrder: 'asc' },
+        { sortBy: 'coordinate', sortOrder: SortOrder.ASC },
       );
 
       expect(getValues(testIslands, 'code')).toEqual(
@@ -264,11 +268,14 @@ describe('RegencyController', () => {
     it('should return all islands in the matching regency sorted by coordinate descending', async () => {
       const testIslands = await controller.findIslands(
         { code: testRegencyCode },
-        { sortBy: 'coordinate', sortOrder: 'desc' },
+        { sortBy: 'coordinate', sortOrder: SortOrder.DESC },
       );
 
       expect(getValues(testIslands, 'code')).toEqual(
-        getValues(sortArray(expectedIslands, 'coordinate', 'desc'), 'code'),
+        getValues(
+          sortArray(expectedIslands, 'coordinate', SortOrder.DESC),
+          'code',
+        ),
       );
     });
   });

--- a/src/sort/sort.dto.ts
+++ b/src/sort/sort.dto.ts
@@ -4,8 +4,8 @@ import { IsOptional, IsString } from 'class-validator';
 import { SortOptions } from './sort.service';
 
 export enum SortOrder {
-  asc = 'asc',
-  desc = 'desc',
+  ASC = 'asc',
+  DESC = 'desc',
 }
 
 /**

--- a/src/village/village.controller.spec.ts
+++ b/src/village/village.controller.spec.ts
@@ -1,5 +1,6 @@
 import { getValues, sortArray } from '@/common/utils/array';
 import { getVillages } from '@/common/utils/data';
+import { SortOrder } from '@/sort/sort.dto';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Village } from '@prisma/client';
@@ -93,11 +94,14 @@ describe('VillageController', () => {
       const testVillages = await controller.find({
         name: testVillageName,
         sortBy: 'name',
-        sortOrder: 'desc',
+        sortOrder: SortOrder.DESC,
       });
 
       expect(getValues(testVillages, 'code')).toEqual(
-        getValues(sortArray(filteredVillagesByName, 'name', 'desc'), 'code'),
+        getValues(
+          sortArray(filteredVillagesByName, 'name', SortOrder.DESC),
+          'code',
+        ),
       );
     });
   });

--- a/test/helper/app-tester.ts
+++ b/test/helper/app-tester.ts
@@ -1,5 +1,5 @@
 import { AppController } from '@/app.controller';
-import { SuccessfulResponse } from '@/common/interceptor/transform.interceptor';
+import { TransformedResponse } from '@/common/interceptor/transform.interceptor';
 import { DistrictModule } from '@/district/district.module';
 import { IslandModule } from '@/island/island.module';
 import { ProvinceModule } from '@/province/province.module';
@@ -112,7 +112,7 @@ export class AppTester {
    */
   async expectData<T>(url: string, method: HttpMethods = 'GET') {
     const res = await this.expectOk(url, method);
-    const resJson = res.json<SuccessfulResponse<T>>();
+    const resJson = res.json<TransformedResponse<T>>();
 
     expect(resJson.data).toBeDefined();
 

--- a/test/helper/app-tester.ts
+++ b/test/helper/app-tester.ts
@@ -1,8 +1,5 @@
 import { AppController } from '@/app.controller';
-import {
-  SuccessfulResponse,
-  TransformInterceptor,
-} from '@/common/interceptor/transform.interceptor';
+import { SuccessfulResponse } from '@/common/interceptor/transform.interceptor';
 import { DistrictModule } from '@/district/district.module';
 import { IslandModule } from '@/island/island.module';
 import { ProvinceModule } from '@/province/province.module';
@@ -10,7 +7,6 @@ import { RegencyModule } from '@/regency/regency.module';
 import { VillageModule } from '@/village/village.module';
 import { ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_INTERCEPTOR } from '@nestjs/core';
 import {
   FastifyAdapter,
   NestFastifyApplication,
@@ -49,12 +45,6 @@ export class AppTester {
         IslandModule,
       ],
       controllers: [AppController],
-      providers: [
-        {
-          provide: APP_INTERCEPTOR,
-          useClass: TransformInterceptor,
-        },
-      ],
     }).compile();
 
     const app = moduleRef.createNestApplication<NestFastifyApplication>(

--- a/test/helper/app-tester.ts
+++ b/test/helper/app-tester.ts
@@ -117,7 +117,7 @@ export class AppTester {
     expect(resJson.data).toBeDefined();
 
     if (Array.isArray(resJson.data)) {
-      expect(resJson.total).toEqual(resJson.data.length);
+      expect(resJson.meta.total).toEqual(resJson.data.length);
     }
 
     return resJson.data;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [x] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using "x"

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

Issue Number: #183 

## What is the new behavior?

- Update the `TransformInterceptor` and `@ApiDataResponse()` decorator to support `meta` property.
- Bind the `TransformInterceptor` inside the `@ApiDataResponse()` decorator (method-scoped interceptor).
- Rename `SuccessfulResponse` to be `TransformedResponse`.
- Fix unit tests for controllers by using `SortOrder.DESC` enum.

## Other information

None