### PR TITLE
Make `name` query param optional

### DIFF
--- a/src/district/district.dto.ts
+++ b/src/district/district.dto.ts
@@ -1,7 +1,12 @@
 import { EqualsAny } from '@/common/decorator/EqualsAny';
 import { IsNotSymbol } from '@/common/decorator/IsNotSymbol';
 import { SortQuery } from '@/sort/sort.dto';
-import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
+import {
+  ApiProperty,
+  IntersectionType,
+  PartialType,
+  PickType,
+} from '@nestjs/swagger';
 import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
 import { VillageSortQuery } from '../village/village.dto';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
@@ -16,7 +21,7 @@ export class District {
   @IsNotEmpty()
   @IsNotSymbol("'()-./")
   @Length(3, 255)
-  @ApiProperty({ example: 'Bakongan' })
+  @ApiProperty({ description: 'The district name', example: 'Bakongan' })
   name: string;
 
   @IsNotEmpty()
@@ -32,7 +37,7 @@ export class DistrictSortQuery extends SortQuery {
 }
 
 export class DistrictFindQueries extends IntersectionType(
-  PickType(District, ['name'] as const),
+  PartialType(PickType(District, ['name'] as const)),
   DistrictSortQuery,
   PaginationQuery,
 ) {}

--- a/src/island/island.dto.ts
+++ b/src/island/island.dto.ts
@@ -1,5 +1,10 @@
 import { SortQuery } from '@/sort/sort.dto';
-import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
+import {
+  ApiProperty,
+  IntersectionType,
+  PartialType,
+  PickType,
+} from '@nestjs/swagger';
 import {
   IsBooleanString,
   IsNotEmpty,
@@ -38,7 +43,10 @@ export class Island {
   @IsNotEmpty()
   @IsNotSymbol("'-/")
   @Length(3, 255)
-  @ApiProperty({ example: 'Pulau Batukapal' })
+  @ApiProperty({
+    description: 'The island name',
+    example: 'Pulau Batukapal',
+  })
   name: string;
 
   @IsOptional()
@@ -60,7 +68,7 @@ export class IslandSortQuery extends SortQuery {
 }
 
 export class IslandFindQueries extends IntersectionType(
-  PickType(Island, ['name'] as const),
+  PartialType(PickType(Island, ['name'] as const)),
   IslandSortQuery,
   PaginationQuery,
 ) {}

--- a/src/province/province.controller.ts
+++ b/src/province/province.controller.ts
@@ -30,16 +30,7 @@ import { ApiPaginatedResponse } from '@/common/decorator/api-paginated-response.
 export class ProvinceController {
   constructor(private readonly provinceService: ProvinceService) {}
 
-  @ApiOperation({
-    description: `Get the provinces. If the \`name\` is empty, all provinces will be returned.
-      Otherwise, it will only return the provinces with the matching name.
-    `,
-  })
-  @ApiQuery({
-    name: 'name',
-    description: 'Get provinces by its name.',
-    required: false,
-  })
+  @ApiOperation({ description: 'Get the provinces.' })
   @ApiQuery({
     name: 'sortBy',
     description: 'Sort by province code or name.',

--- a/src/province/province.dto.ts
+++ b/src/province/province.dto.ts
@@ -21,7 +21,7 @@ export class Province {
   @IsNotEmpty()
   @IsNotSymbol()
   @Length(3, 255)
-  @ApiProperty({ example: 'ACEH' })
+  @ApiProperty({ description: 'The province name', example: 'ACEH' })
   name: string;
 }
 

--- a/src/regency/regency.controller.ts
+++ b/src/regency/regency.controller.ts
@@ -32,7 +32,7 @@ import { PaginatedReturn } from '@/common/interceptor/paginate.interceptor';
 export class RegencyController {
   constructor(private readonly regencyService: RegencyService) {}
 
-  @ApiOperation({ description: 'Get the regencies by its name.' })
+  @ApiOperation({ description: 'Get the regencies.' })
   @ApiQuery({
     name: 'sortBy',
     description: 'Sort by regency code or name.',

--- a/src/regency/regency.dto.ts
+++ b/src/regency/regency.dto.ts
@@ -1,7 +1,12 @@
 import { EqualsAny } from '@/common/decorator/EqualsAny';
 import { IsNotSymbol } from '@/common/decorator/IsNotSymbol';
 import { SortQuery } from '@/sort/sort.dto';
-import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
+import {
+  ApiProperty,
+  IntersectionType,
+  PartialType,
+  PickType,
+} from '@nestjs/swagger';
 import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
 import { DistrictSortQuery } from '../district/district.dto';
 import { IslandSortQuery } from '../island/island.dto';
@@ -17,7 +22,10 @@ export class Regency {
   @IsNotEmpty()
   @IsNotSymbol()
   @Length(3, 255)
-  @ApiProperty({ example: 'KABUPATEN ACEH SELATAN' })
+  @ApiProperty({
+    description: 'The regency name',
+    example: 'KABUPATEN ACEH SELATAN',
+  })
   name: string;
 
   @IsNotEmpty()
@@ -33,7 +41,7 @@ export class RegencySortQuery extends SortQuery {
 }
 
 export class RegencyFindQueries extends IntersectionType(
-  PickType(Regency, ['name'] as const),
+  PartialType(PickType(Regency, ['name'] as const)),
   RegencySortQuery,
   PaginationQuery,
 ) {}

--- a/src/village/village.dto.ts
+++ b/src/village/village.dto.ts
@@ -2,7 +2,12 @@ import { EqualsAny } from '@/common/decorator/EqualsAny';
 import { IsNotSymbol } from '@/common/decorator/IsNotSymbol';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
 import { SortQuery } from '@/sort/sort.dto';
-import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
+import {
+  ApiProperty,
+  IntersectionType,
+  PartialType,
+  PickType,
+} from '@nestjs/swagger';
 import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
 
 export class Village {
@@ -15,7 +20,7 @@ export class Village {
   @IsNotEmpty()
   @IsNotSymbol("'()-./")
   @Length(3, 255)
-  @ApiProperty({ example: 'Keude Bakongan' })
+  @ApiProperty({ description: 'The village name', example: 'Keude Bakongan' })
   name: string;
 
   @IsNotEmpty()
@@ -31,7 +36,7 @@ export class VillageSortQuery extends SortQuery {
 }
 
 export class VillageFindQueries extends IntersectionType(
-  PickType(Village, ['name'] as const),
+  PartialType(PickType(Village, ['name'] as const)),
   VillageSortQuery,
   PaginationQuery,
 ) {}

--- a/test/district.e2e-spec.ts
+++ b/test/district.e2e-spec.ts
@@ -13,9 +13,17 @@ describe('District (e2e)', () => {
     await tester.bootApp();
   });
 
-  describe(`GET ${baseUrl}?name={name}`, () => {
-    it('should return 400 if the `name` does not present', async () => {
-      await tester.expectBadRequest(`${baseUrl}`);
+  describe(`GET ${baseUrl}`, () => {
+    it('should return districts', async () => {
+      const districts = await tester.expectData<District[]>(baseUrl);
+
+      districts.forEach((district) => {
+        expect(district).toEqual({
+          code: expect.stringMatching(districtRegex.code),
+          name: expect.stringMatching(districtRegex.name),
+          regencyCode: district.code.slice(0, 4),
+        });
+      });
     });
 
     it("should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any other symbols besides '()-./", async () => {

--- a/test/island.e2e-spec.ts
+++ b/test/island.e2e-spec.ts
@@ -13,9 +13,22 @@ describe('Island (e2e)', () => {
     await tester.bootApp();
   });
 
-  describe(`GET ${baseUrl}?name={name}`, () => {
-    it('should return 400 if the `name` does not present', async () => {
-      await tester.expectBadRequest(`${baseUrl}`);
+  describe(`GET ${baseUrl}`, () => {
+    it('should return islands', async () => {
+      const islands = await tester.expectData<Island[]>(baseUrl);
+
+      islands.forEach((island) => {
+        expect(island).toEqual({
+          code: expect.stringMatching(islandRegex.code),
+          coordinate: expect.stringMatching(islandRegex.coordinate),
+          isOutermostSmall: expect.any(Boolean),
+          isPopulated: expect.any(Boolean),
+          latitude: expect.any(Number),
+          longitude: expect.any(Number),
+          name: expect.stringMatching(islandRegex.name),
+          regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
+        });
+      });
     });
 
     it('should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any symbols', async () => {

--- a/test/regency.e2e-spec.ts
+++ b/test/regency.e2e-spec.ts
@@ -13,9 +13,17 @@ describe('Regency (e2e)', () => {
     await tester.bootApp();
   });
 
-  describe(`GET ${baseUrl}?name={name}`, () => {
-    it('should return 400 if the `name` does not present', async () => {
-      await tester.expectBadRequest(`${baseUrl}`);
+  describe(`GET ${baseUrl}`, () => {
+    it('should return regencies', async () => {
+      const regencies = await tester.expectData<Regency[]>(baseUrl);
+
+      regencies.forEach((regency) => {
+        expect(regency).toEqual({
+          code: expect.stringMatching(regencyRegex.code),
+          name: expect.stringMatching(regencyRegex.name),
+          provinceCode: expect.stringMatching(regencyRegex.provinceCode),
+        });
+      });
     });
 
     it('should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any symbols', async () => {

--- a/test/village.e2e-spec.ts
+++ b/test/village.e2e-spec.ts
@@ -13,9 +13,17 @@ describe('Village (e2e)', () => {
     await tester.bootApp();
   });
 
-  describe(`GET ${baseUrl}?name={name}`, () => {
-    it('should return 400 if the `name` does not present', async () => {
-      await tester.expectBadRequest(`${baseUrl}`);
+  describe(`GET ${baseUrl}`, () => {
+    it('should return villages', async () => {
+      const villages = await tester.expectData<Village[]>(baseUrl);
+
+      villages.forEach((village) => {
+        expect(village).toEqual({
+          code: expect.stringMatching(villageRegex.code),
+          name: expect.stringMatching(villageRegex.name),
+          districtCode: village.code.slice(0, 6),
+        });
+      });
     });
 
     it("should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any other symbols besides '()-./", async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [x] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

Issue Number: #188 

## What is the new behavior?

Now `name` query param of these endpoints below are optional:
- `/regencies`
- `/districts`
- `/islands`
- `/villages`

## Other information
None
