### PR TITLE
Remove min length restriction for `name` query

### DIFF
--- a/src/district/district.dto.ts
+++ b/src/district/district.dto.ts
@@ -7,7 +7,7 @@ import {
   PartialType,
   PickType,
 } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
+import { IsNotEmpty, IsNumberString, Length, MaxLength } from 'class-validator';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
 
 export class District {
@@ -17,9 +17,8 @@ export class District {
   @ApiProperty({ description: 'The district code', example: '110101' })
   code: string;
 
-  @IsNotEmpty()
   @IsNotSymbol("'()-./")
-  @Length(3, 255)
+  @MaxLength(100)
   @ApiProperty({ description: 'The district name', example: 'Bakongan' })
   name: string;
 

--- a/src/island/island.dto.ts
+++ b/src/island/island.dto.ts
@@ -12,6 +12,7 @@ import {
   IsOptional,
   IsString,
   Length,
+  MaxLength,
   ValidateIf,
 } from 'class-validator';
 import { EqualsAny } from '../common/decorator/EqualsAny';
@@ -41,9 +42,8 @@ export class Island {
   @ApiProperty({ example: false })
   isPopulated: boolean;
 
-  @IsNotEmpty()
   @IsNotSymbol("'-/")
-  @Length(3, 255)
+  @MaxLength(100)
   @ApiProperty({
     description: 'The island name',
     example: 'Pulau Batukapal',

--- a/src/province/province.dto.ts
+++ b/src/province/province.dto.ts
@@ -7,7 +7,7 @@ import {
   PartialType,
   PickType,
 } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
+import { IsNotEmpty, IsNumberString, Length, MaxLength } from 'class-validator';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
 
 export class Province {
@@ -17,9 +17,8 @@ export class Province {
   @ApiProperty({ description: 'The province code', example: '11' })
   code: string;
 
-  @IsNotEmpty()
   @IsNotSymbol()
-  @Length(3, 255)
+  @MaxLength(100)
   @ApiProperty({ description: 'The province name', example: 'ACEH' })
   name: string;
 }

--- a/src/regency/regency.dto.ts
+++ b/src/regency/regency.dto.ts
@@ -7,7 +7,7 @@ import {
   PartialType,
   PickType,
 } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
+import { IsNotEmpty, IsNumberString, Length, MaxLength } from 'class-validator';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
 
 export class Regency {
@@ -17,9 +17,8 @@ export class Regency {
   @ApiProperty({ description: 'The regency code', example: '1101' })
   code: string;
 
-  @IsNotEmpty()
   @IsNotSymbol()
-  @Length(3, 255)
+  @MaxLength(100)
   @ApiProperty({
     description: 'The regency name',
     example: 'KABUPATEN ACEH SELATAN',

--- a/src/village/village.dto.ts
+++ b/src/village/village.dto.ts
@@ -8,7 +8,7 @@ import {
   PartialType,
   PickType,
 } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumberString, Length } from 'class-validator';
+import { IsNotEmpty, IsNumberString, Length, MaxLength } from 'class-validator';
 
 export class Village {
   @IsNotEmpty()
@@ -17,9 +17,8 @@ export class Village {
   @ApiProperty({ description: 'The village code', example: '1101012001' })
   code: string;
 
-  @IsNotEmpty()
   @IsNotSymbol("'()-./")
-  @Length(3, 255)
+  @MaxLength(100)
   @ApiProperty({ description: 'The village name', example: 'Keude Bakongan' })
   name: string;
 

--- a/test/district.e2e-spec.ts
+++ b/test/district.e2e-spec.ts
@@ -26,8 +26,8 @@ describe('District (e2e)', () => {
       });
     });
 
-    it("should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any other symbols besides '()-./", async () => {
-      const invalidNames = ['', 'ab', 'x'.repeat(256), 'b@ndung'];
+    it("should return 400 if the `name` is more than 100 chars, or contains any other symbols besides '()-./", async () => {
+      const invalidNames = ['x'.repeat(101), 'b@ndung'];
 
       for (const name of invalidNames) {
         await tester.expectBadRequest(`${baseUrl}?name=${name}`);

--- a/test/island.e2e-spec.ts
+++ b/test/island.e2e-spec.ts
@@ -31,8 +31,8 @@ describe('Island (e2e)', () => {
       });
     });
 
-    it('should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any symbols', async () => {
-      const invalidNames = ['', 'ab', 'x'.repeat(256), 's@bang'];
+    it('should return 400 if the `name` is more than 100 chars, or contains any symbols', async () => {
+      const invalidNames = ['x'.repeat(101), 's@bang'];
 
       for (const name of invalidNames) {
         await tester.expectBadRequest(`${baseUrl}?name=${name}`);

--- a/test/province.e2e-spec.ts
+++ b/test/province.e2e-spec.ts
@@ -34,8 +34,8 @@ describe('Province (e2e)', () => {
   });
 
   describe(`GET ${baseUrl}?name={name}`, () => {
-    it('should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any symbols', async () => {
-      const invalidNames = ['', 'ab', 'x'.repeat(256), 'j@wa'];
+    it('should return 400 if the `name` is more than 100 chars, or contains any symbols', async () => {
+      const invalidNames = ['x'.repeat(101), 'j@wa'];
 
       for (const name of invalidNames) {
         await tester.expectBadRequest(`${baseUrl}?name=${name}`);

--- a/test/regency.e2e-spec.ts
+++ b/test/regency.e2e-spec.ts
@@ -26,8 +26,8 @@ describe('Regency (e2e)', () => {
       });
     });
 
-    it('should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any symbols', async () => {
-      const invalidNames = ['', 'ab', 'x'.repeat(256), 'b@ndung'];
+    it('should return 400 if the `name` is more than 100 chars, or contains any symbols', async () => {
+      const invalidNames = ['x'.repeat(101), 'b@ndung'];
 
       for (const name of invalidNames) {
         await tester.expectBadRequest(`${baseUrl}?name=${name}`);

--- a/test/village.e2e-spec.ts
+++ b/test/village.e2e-spec.ts
@@ -26,8 +26,8 @@ describe('Village (e2e)', () => {
       });
     });
 
-    it("should return 400 if the `name` is empty, less than 3 chars, more than 255 chars, or contains any other symbols besides '()-./", async () => {
-      const invalidNames = ['', 'ab', 'x'.repeat(256), 'c!nunuk'];
+    it("should return 400 if the `name` more than 100 chars, or contains any other symbols besides '()-./", async () => {
+      const invalidNames = ['x'.repeat(101), 'c!nunuk'];
 
       for (const name of invalidNames) {
         await tester.expectBadRequest(`${baseUrl}?name=${name}`);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [x] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

Since the pagination feature is available, the minimum character length restriction for `name` query is no longer necessary.

## What is the new behavior?

- Remove minimum character length for `name` query
- Set maximum character length for `name` query to 100
- Allow empty value for `name` query (`?name=` is valid now)

## Other information

None
