### PR TITLE
Add `parent` data into `GET /{area}/{code}` endpoints

### DIFF
--- a/src/district/district.controller.ts
+++ b/src/district/district.controller.ts
@@ -17,6 +17,7 @@ import {
   District,
   DistrictFindByCodeParams,
   DistrictFindQueries,
+  DistrictWithParent,
 } from './district.dto';
 import { DistrictService } from './district.service';
 import { ApiPaginatedResponse } from '@/common/decorator/api-paginated-response.decorator';
@@ -48,7 +49,10 @@ export class DistrictController {
   }
 
   @ApiOperation({ description: 'Get a district by its code.' })
-  @ApiDataResponse({ model: District, description: 'Returns a district.' })
+  @ApiDataResponse({
+    model: DistrictWithParent,
+    description: 'Returns a district.',
+  })
   @ApiBadRequestResponse({ description: 'If the `code` is invalid.' })
   @ApiNotFoundResponse({
     description: 'If no district matches the `code`.',
@@ -56,7 +60,7 @@ export class DistrictController {
   @Get(':code')
   async findByCode(
     @Param() { code }: DistrictFindByCodeParams,
-  ): Promise<District> {
+  ): Promise<DistrictWithParent> {
     const district = await this.districtService.findByCode(code);
 
     if (district === null) {

--- a/src/district/district.dto.ts
+++ b/src/district/district.dto.ts
@@ -9,6 +9,8 @@ import {
 } from '@nestjs/swagger';
 import { IsNotEmpty, IsNumberString, Length, MaxLength } from 'class-validator';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
+import { Regency } from '@/regency/regency.dto';
+import { Province } from '@/province/province.dto';
 
 export class District {
   @IsNotEmpty()
@@ -46,3 +48,10 @@ export class DistrictFindQueries extends IntersectionType(
 export class DistrictFindByCodeParams extends PickType(District, [
   'code',
 ] as const) {}
+
+export class DistrictWithParent extends District {
+  parent: {
+    regency: Regency;
+    province: Province;
+  };
+}

--- a/src/district/district.service.spec.ts
+++ b/src/district/district.service.spec.ts
@@ -26,10 +26,7 @@ describe('DistrictService', () => {
         DistrictService,
         {
           provide: PrismaService,
-          useValue: {
-            ...mockPrismaService('District', districts),
-            province: mockPrismaService('Province', provinces).province,
-          },
+          useValue: mockPrismaService('District', districts),
         },
       ],
     }).compile();
@@ -166,10 +163,6 @@ describe('DistrictService', () => {
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
-      expect(findUniqueSpy).toHaveBeenCalledWith({
-        where: { code: testCode },
-        include: { regency: true },
-      });
       expect(result).toBeNull();
     });
 
@@ -189,21 +182,15 @@ describe('DistrictService', () => {
           ...expectedDistrict,
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
-          regency: expectedRegency,
+          regency: {
+            ...expectedRegency,
+            province: expectedProvince,
+          },
         });
-
-      vitest
-        .spyOn(prismaService.province, 'findUnique')
-        .mockResolvedValue(expectedProvince);
 
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
-      expect(findUniqueSpy).toHaveBeenCalledWith({
-        where: { code: testCode },
-        include: { regency: true },
-      });
-
       expect(result).toEqual({
         ...expectedDistrict,
         parent: {

--- a/src/district/district.service.spec.ts
+++ b/src/district/district.service.spec.ts
@@ -163,6 +163,9 @@ describe('DistrictService', () => {
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
+      expect(findUniqueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { code: testCode } }),
+      );
       expect(result).toBeNull();
     });
 
@@ -191,6 +194,9 @@ describe('DistrictService', () => {
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
+      expect(findUniqueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { code: testCode } }),
+      );
       expect(result).toEqual({
         ...expectedDistrict,
         parent: {

--- a/src/district/district.service.ts
+++ b/src/district/district.service.ts
@@ -47,23 +47,27 @@ export class DistrictService {
   async findByCode(code: string): Promise<DistrictWithParent | null> {
     const res = await this.prisma.district.findUnique({
       where: { code },
-      include: { regency: true },
+      include: {
+        regency: {
+          include: {
+            province: true,
+          },
+        },
+      },
     });
 
     if (!res) {
       return null;
     }
 
-    const { regency, ...district } = res;
+    const {
+      regency: { province, ...regency },
+      ...district
+    } = res;
 
     return {
       ...district,
-      parent: {
-        regency,
-        province: await this.prisma.province.findUnique({
-          where: { code: regency.provinceCode },
-        }),
-      },
+      parent: { regency, province },
     };
   }
 }

--- a/src/island/island.controller.ts
+++ b/src/island/island.controller.ts
@@ -17,6 +17,7 @@ import {
   Island,
   IslandFindByCodeParams,
   IslandFindQueries,
+  IslandWithParent,
 } from './island.dto';
 import { IslandService } from './island.service';
 import { ApiPaginatedResponse } from '@/common/decorator/api-paginated-response.decorator';
@@ -55,19 +56,24 @@ export class IslandController {
   }
 
   @ApiOperation({ description: 'Get an island by its code.' })
-  @ApiDataResponse({ model: Island, description: 'Returns an island.' })
+  @ApiDataResponse({
+    model: IslandWithParent,
+    description: 'Returns an island.',
+  })
   @ApiBadRequestResponse({ description: 'If the `code` is invalid.' })
   @ApiNotFoundResponse({
     description: 'If no island matches the `code`.',
   })
   @Get(':code')
-  async findByCode(@Param() { code }: IslandFindByCodeParams): Promise<Island> {
+  async findByCode(
+    @Param() { code }: IslandFindByCodeParams,
+  ): Promise<IslandWithParent> {
     const island = await this.islandService.findByCode(code);
 
     if (island === null) {
       throw new NotFoundException(`Island with code ${code} not found.`);
     }
 
-    return this.islandService.addDecimalCoordinate(island);
+    return island;
   }
 }

--- a/src/island/island.dto.ts
+++ b/src/island/island.dto.ts
@@ -18,6 +18,8 @@ import {
 import { EqualsAny } from '../common/decorator/EqualsAny';
 import { IsNotSymbol } from '../common/decorator/IsNotSymbol';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
+import { Regency } from '@/regency/regency.dto';
+import { Province } from '@/province/province.dto';
 
 export class Island {
   @IsNotEmpty()
@@ -59,7 +61,7 @@ export class Island {
       Providing an empty string will filter islands that are not part of any regency.`,
     example: '1101',
   })
-  regencyCode?: string;
+  regencyCode?: string | null;
 
   @ApiProperty({ example: 3.317622222222222 })
   latitude?: number;
@@ -82,3 +84,10 @@ export class IslandFindQueries extends IntersectionType(
 export class IslandFindByCodeParams extends PickType(Island, [
   'code',
 ] as const) {}
+
+export class IslandWithParent extends Island {
+  parent: {
+    regency?: Regency | null;
+    province: Province;
+  };
+}

--- a/src/regency/regency.controller.ts
+++ b/src/regency/regency.controller.ts
@@ -17,6 +17,7 @@ import {
 import {
   Regency,
   RegencyFindByCodeParams,
+  RegencyWithParent,
   RegencyFindQueries,
 } from './regency.dto';
 import { RegencyService } from './regency.service';
@@ -48,7 +49,10 @@ export class RegencyController {
   }
 
   @ApiOperation({ description: 'Get a regency by its code.' })
-  @ApiDataResponse({ model: Regency, description: 'Returns a regency.' })
+  @ApiDataResponse({
+    model: RegencyWithParent,
+    description: 'Returns a regency.',
+  })
   @ApiBadRequestResponse({ description: 'If the `code` is invalid.' })
   @ApiNotFoundResponse({
     description: 'If no regency matches the `code`.',
@@ -56,7 +60,7 @@ export class RegencyController {
   @Get(':code')
   async findByCode(
     @Param() { code }: RegencyFindByCodeParams,
-  ): Promise<Regency> {
+  ): Promise<RegencyWithParent> {
     const regency = await this.regencyService.findByCode(code);
 
     if (regency === null) {

--- a/src/regency/regency.dto.ts
+++ b/src/regency/regency.dto.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/swagger';
 import { IsNotEmpty, IsNumberString, Length, MaxLength } from 'class-validator';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
+import { Province } from '@/province/province.dto';
 
 export class Regency {
   @IsNotEmpty()
@@ -49,3 +50,9 @@ export class RegencyFindQueries extends IntersectionType(
 export class RegencyFindByCodeParams extends PickType(Regency, [
   'code',
 ] as const) {}
+
+export class RegencyWithParent extends Regency {
+  parent: {
+    province: Province;
+  };
+}

--- a/src/regency/regency.service.spec.ts
+++ b/src/regency/regency.service.spec.ts
@@ -169,10 +169,9 @@ describe('RegencyService', () => {
       const result = await service.findByCode(expectedRegency.code);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
-      expect(findUniqueSpy).toHaveBeenCalledWith({
-        where: { code: expectedRegency.code },
-        include: { province: true },
-      });
+      expect(findUniqueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { code: expectedRegency.code } }),
+      );
 
       expect(result).toEqual({
         ...expectedRegency,
@@ -191,10 +190,9 @@ describe('RegencyService', () => {
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
-      expect(findUniqueSpy).toHaveBeenCalledWith({
-        where: { code: testCode },
-        include: { province: true },
-      });
+      expect(findUniqueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { code: testCode } }),
+      );
       expect(result).toBeNull();
     });
   });

--- a/src/regency/regency.service.spec.ts
+++ b/src/regency/regency.service.spec.ts
@@ -24,10 +24,7 @@ describe('RegencyService', () => {
         RegencyService,
         {
           provide: PrismaService,
-          useValue: {
-            ...mockPrismaService('Regency', regencies),
-            province: mockPrismaService('Province', provinces).province,
-          },
+          useValue: mockPrismaService('Regency', regencies),
         },
       ],
     }).compile();
@@ -162,22 +159,19 @@ describe('RegencyService', () => {
 
       const findUniqueSpy = vitest
         .spyOn(prismaService.regency, 'findUnique')
-        .mockResolvedValue(expectedRegency);
-
-      const findUniqueProvinceSpy = vitest
-        .spyOn(prismaService.province, 'findUnique')
-        .mockResolvedValue(expectedProvince);
+        .mockReturnValue({
+          ...expectedRegency,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          province: expectedProvince,
+        });
 
       const result = await service.findByCode(expectedRegency.code);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
       expect(findUniqueSpy).toHaveBeenCalledWith({
         where: { code: expectedRegency.code },
-      });
-
-      expect(findUniqueProvinceSpy).toHaveBeenCalledTimes(1);
-      expect(findUniqueProvinceSpy).toHaveBeenCalledWith({
-        where: { code: expectedRegency.provinceCode },
+        include: { province: true },
       });
 
       expect(result).toEqual({
@@ -199,6 +193,7 @@ describe('RegencyService', () => {
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
       expect(findUniqueSpy).toHaveBeenCalledWith({
         where: { code: testCode },
+        include: { province: true },
       });
       expect(result).toBeNull();
     });

--- a/src/regency/regency.service.ts
+++ b/src/regency/regency.service.ts
@@ -44,25 +44,20 @@ export class RegencyService {
   }
 
   async findByCode(code: string): Promise<RegencyWithParent | null> {
-    const regency = await this.prisma.regency.findUnique({
-      where: {
-        code: code,
-      },
+    const res = await this.prisma.regency.findUnique({
+      where: { code },
+      include: { province: true },
     });
 
-    if (!regency) {
+    if (!res) {
       return null;
     }
 
+    const { province, ...regency } = res;
+
     return {
       ...regency,
-      parent: {
-        province: await this.prisma.province.findUnique({
-          where: {
-            code: regency.provinceCode,
-          },
-        }),
-      },
+      parent: { province },
     };
   }
 }

--- a/src/regency/regency.service.ts
+++ b/src/regency/regency.service.ts
@@ -4,7 +4,7 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { SortService } from '@/sort/sort.service';
 import { Injectable } from '@nestjs/common';
 import { Regency } from '@prisma/client';
-import { RegencyFindQueries } from './regency.dto';
+import { RegencyWithParent, RegencyFindQueries } from './regency.dto';
 
 @Injectable()
 export class RegencyService {
@@ -43,11 +43,26 @@ export class RegencyService {
     });
   }
 
-  async findByCode(code: string): Promise<Regency | null> {
-    return this.prisma.regency.findUnique({
+  async findByCode(code: string): Promise<RegencyWithParent | null> {
+    const regency = await this.prisma.regency.findUnique({
       where: {
         code: code,
       },
     });
+
+    if (!regency) {
+      return null;
+    }
+
+    return {
+      ...regency,
+      parent: {
+        province: await this.prisma.province.findUnique({
+          where: {
+            code: regency.provinceCode,
+          },
+        }),
+      },
+    };
   }
 }

--- a/src/village/village.controller.ts
+++ b/src/village/village.controller.ts
@@ -17,6 +17,7 @@ import {
   Village,
   VillageFindByCodeParams,
   VillageFindQueries,
+  VillageWithParent,
 } from './village.dto';
 import { VillageService } from './village.service';
 import { ApiPaginatedResponse } from '@/common/decorator/api-paginated-response.decorator';
@@ -48,7 +49,10 @@ export class VillageController {
   }
 
   @ApiOperation({ description: 'Get a village by its code.' })
-  @ApiDataResponse({ model: Village, description: 'Returns a village.' })
+  @ApiDataResponse({
+    model: VillageWithParent,
+    description: 'Returns a village.',
+  })
   @ApiBadRequestResponse({ description: 'If the `code` is invalid.' })
   @ApiNotFoundResponse({
     description: 'If no village matches the `code`.',
@@ -56,7 +60,7 @@ export class VillageController {
   @Get(':code')
   async findByCode(
     @Param() { code }: VillageFindByCodeParams,
-  ): Promise<Village> {
+  ): Promise<VillageWithParent> {
     const village = await this.villageService.findByCode(code);
 
     if (village === null) {

--- a/src/village/village.dto.ts
+++ b/src/village/village.dto.ts
@@ -1,6 +1,9 @@
 import { EqualsAny } from '@/common/decorator/EqualsAny';
 import { IsNotSymbol } from '@/common/decorator/IsNotSymbol';
 import { PaginationQuery } from '@/common/dto/pagination.dto';
+import { District } from '@/district/district.dto';
+import { Province } from '@/province/province.dto';
+import { Regency } from '@/regency/regency.dto';
 import { SortQuery } from '@/sort/sort.dto';
 import {
   ApiProperty,
@@ -46,3 +49,11 @@ export class VillageFindQueries extends IntersectionType(
 export class VillageFindByCodeParams extends PickType(Village, [
   'code',
 ] as const) {}
+
+export class VillageWithParent extends Village {
+  parent: {
+    district: District;
+    regency: Regency;
+    province: Province;
+  };
+}

--- a/src/village/village.service.spec.ts
+++ b/src/village/village.service.spec.ts
@@ -171,6 +171,9 @@ describe('VillageService', () => {
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
+      expect(findUniqueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { code: testCode } }),
+      );
       expect(result).toBeNull();
     });
 
@@ -205,6 +208,9 @@ describe('VillageService', () => {
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
+      expect(findUniqueSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { code: testCode } }),
+      );
       expect(result).toEqual({
         ...expectedVillage,
         parent: {

--- a/src/village/village.service.spec.ts
+++ b/src/village/village.service.spec.ts
@@ -2,20 +2,30 @@ import { getDBProviderFeatures } from '@common/utils/db';
 import { PrismaService } from '@/prisma/prisma.service';
 import { SortOrder } from '@/sort/sort.dto';
 import { Test } from '@nestjs/testing';
-import { Village } from '@prisma/client';
+import { District, Province, Regency, Village } from '@prisma/client';
 import { VillageService } from './village.service';
 import { mockPrismaService } from '@/prisma/__mocks__/prisma.service';
-
-const villages: readonly Village[] = [
-  { code: '1101012001', name: 'Desa 1', districtCode: '110101' },
-  { code: '1101012002', name: 'Desa 2', districtCode: '110101' },
-  { code: '1212121001', name: 'Kampung Karet', districtCode: '121212' },
-  { code: '1212121002', name: 'Kampung Berkah', districtCode: '121212' },
-] as const;
+import {
+  getDistricts,
+  getProvinces,
+  getRegencies,
+  getVillages,
+} from '@common/utils/data';
 
 describe('VillageService', () => {
+  let villages: Village[];
+  let districts: District[];
+  let regencies: Regency[];
+  let provinces: Province[];
   let service: VillageService;
   let prismaService: PrismaService;
+
+  beforeAll(async () => {
+    villages = await getVillages();
+    districts = await getDistricts();
+    regencies = await getRegencies();
+    provinces = await getProvinces();
+  });
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -161,27 +171,48 @@ describe('VillageService', () => {
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
-      expect(findUniqueSpy).toHaveBeenCalledWith({
-        where: { code: testCode },
-      });
       expect(result).toBeNull();
     });
 
     it('should return the village with the provided code', async () => {
       const testCode = '1101012001';
       const expectedVillage = villages.find((v) => v.code === testCode);
+      const expectedDistrict = districts.find(
+        (d) => d.code === expectedVillage?.districtCode,
+      );
+      const expectedRegency = regencies.find(
+        (r) => r.code === expectedDistrict?.regencyCode,
+      );
+      const expectedProvince = provinces.find(
+        (p) => p.code === expectedRegency?.provinceCode,
+      );
 
       const findUniqueSpy = vitest
         .spyOn(prismaService.village, 'findUnique')
-        .mockResolvedValue(expectedVillage);
+        .mockResolvedValue({
+          ...expectedVillage,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          district: {
+            ...expectedDistrict,
+            regency: {
+              ...expectedRegency,
+              province: expectedProvince,
+            },
+          },
+        });
 
       const result = await service.findByCode(testCode);
 
       expect(findUniqueSpy).toHaveBeenCalledTimes(1);
-      expect(findUniqueSpy).toHaveBeenCalledWith({
-        where: { code: testCode },
+      expect(result).toEqual({
+        ...expectedVillage,
+        parent: {
+          district: expectedDistrict,
+          regency: expectedRegency,
+          province: expectedProvince,
+        },
       });
-      expect(result).toEqual(expectedVillage);
     });
   });
 });

--- a/test/district.e2e-spec.ts
+++ b/test/district.e2e-spec.ts
@@ -1,6 +1,10 @@
 import { District } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
-import { districtRegex } from './helper/data-regex';
+import {
+  districtRegex,
+  provinceRegex,
+  regencyRegex,
+} from './helper/data-regex';
 import { getEncodedSymbols } from './helper/utils';
 
 describe('District (e2e)', () => {
@@ -105,6 +109,17 @@ describe('District (e2e)', () => {
         code: testCode,
         name: expect.stringMatching(districtRegex.name),
         regencyCode: testCode.slice(0, 4),
+        parent: {
+          regency: {
+            code: testCode.slice(0, 4),
+            name: expect.stringMatching(regencyRegex.name),
+            provinceCode: testCode.slice(0, 2),
+          },
+          province: {
+            code: testCode.slice(0, 2),
+            name: expect.stringMatching(provinceRegex.name),
+          },
+        },
       });
     });
   });

--- a/test/island.e2e-spec.ts
+++ b/test/island.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Island } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
-import { islandRegex } from './helper/data-regex';
+import { islandRegex, regencyRegex } from './helper/data-regex';
 import { getEncodedSymbols } from './helper/utils';
 
 describe('Island (e2e)', () => {
@@ -142,6 +142,19 @@ describe('Island (e2e)', () => {
         longitude: expect.any(Number),
         name: expect.stringMatching(islandRegex.name),
         regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
+        parent: {
+          regency: island.regencyCode
+            ? {
+                code: island.regencyCode,
+                name: expect.stringMatching(regencyRegex.name),
+                provinceCode: island.code.slice(0, 2),
+              }
+            : null,
+          province: {
+            code: island.code.slice(0, 2),
+            name: expect.stringMatching(islandRegex.name),
+          },
+        },
       });
     });
   });

--- a/test/regency.e2e-spec.ts
+++ b/test/regency.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Regency } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
-import { regencyRegex } from './helper/data-regex';
+import { provinceRegex, regencyRegex } from './helper/data-regex';
 import { getEncodedSymbols } from './helper/utils';
 
 describe('Regency (e2e)', () => {
@@ -87,6 +87,12 @@ describe('Regency (e2e)', () => {
         code: testCode,
         name: expect.stringMatching(regencyRegex.name),
         provinceCode: testCode.slice(0, 2),
+        parent: expect.objectContaining({
+          province: expect.objectContaining({
+            code: testCode.slice(0, 2),
+            name: expect.stringMatching(provinceRegex.name),
+          }),
+        }),
       });
     });
   });

--- a/test/village.e2e-spec.ts
+++ b/test/village.e2e-spec.ts
@@ -1,6 +1,11 @@
 import { Village } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
-import { villageRegex } from './helper/data-regex';
+import {
+  districtRegex,
+  provinceRegex,
+  regencyRegex,
+  villageRegex,
+} from './helper/data-regex';
 import { getEncodedSymbols } from './helper/utils';
 
 describe('Village (e2e)', () => {
@@ -105,6 +110,22 @@ describe('Village (e2e)', () => {
         code: testCode,
         name: expect.stringMatching(villageRegex.name),
         districtCode: testCode.slice(0, 6),
+        parent: {
+          district: {
+            code: testCode.slice(0, 6),
+            name: expect.stringMatching(districtRegex.name),
+            regencyCode: testCode.slice(0, 4),
+          },
+          regency: {
+            code: testCode.slice(0, 4),
+            name: expect.stringMatching(regencyRegex.name),
+            provinceCode: testCode.slice(0, 2),
+          },
+          province: {
+            code: testCode.slice(0, 2),
+            name: expect.stringMatching(provinceRegex.name),
+          },
+        },
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [x] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

## What is the new behavior?

Add `parent` property into all `GET /{area}/{code}` endpoints. These are the response examples for each endpoints:

### `GET /regencies/{code}`

```json
{
  "statusCode": 200,
  "message": "OK",
  "data": {
    "code": "1101",
    "name": "KABUPATEN ACEH SELATAN",
    "provinceCode": "11",
    "parent": {
      "province": {
        "code": "11",
        "name": "ACEH"
      }
    }
  },
  "meta": {}
}
```

### `GET /districts/{code}`

```json
{
  "statusCode": 200,
  "message": "OK",
  "data": {
    "code": "110101",
    "name": "Bakongan",
    "regencyCode": "1101",
    "parent": {
      "regency": {
        "code": "1101",
        "name": "KABUPATEN ACEH SELATAN",
        "provinceCode": "11"
      },
      "province": {
        "code": "11",
        "name": "ACEH"
      }
    }
  },
  "meta": {}
}
```

### `GET /villages/{code}`

```json
{
  "statusCode": 200,
  "message": "OK",
  "data": {
    "code": "1101012001",
    "name": "Keude Bakongan",
    "districtCode": "110101",
    "parent": {
      "district": {
        "code": "110101",
        "name": "Bakongan",
        "regencyCode": "1101"
      },
      "regency": {
        "code": "1101",
        "name": "KABUPATEN ACEH SELATAN",
        "provinceCode": "11"
      },
      "province": {
        "code": "11",
        "name": "ACEH"
      }
    }
  },
  "meta": {}
}
```

### `GET /islands/{code}`

```json
{
  "statusCode": 200,
  "message": "OK",
  "data": {
    "code": "110140001",
    "coordinate": "03°19'03.44\" N 097°07'41.73\" E",
    "isOutermostSmall": false,
    "isPopulated": false,
    "name": "Pulau Batukapal",
    "regencyCode": "1101",
    "latitude": 3.317622222222222,
    "longitude": 97.12825833333332,
    "parent": {
      "regency": {
        "code": "1101",
        "name": "KABUPATEN ACEH SELATAN",
        "provinceCode": "11"
      },
      "province": {
        "code": "11",
        "name": "ACEH"
      }
    }
  },
  "meta": {}
}
```

## Other information
None
