### PR TITLE
Bring back MongoDB `id` property to API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ API that provides information on the **administrative areas of Indonesia**, from
 
 Built with [NestJS framework](https://nestjs.com) and writen in TypeScript. [Prisma](https://www.prisma.io) is used as the ORM to interact with any kind of databases (MySQL, PostgreSQL, and MongoDB).
 
-> **⚠️ Upgrading to v3.0.0 ⚠️**
+> **Note!**
 >
-> Since [v3.0.0](https://github.com/fityannugroho/idn-area/releases/tag/v3.0.0), **Node.js v18** or higher is required.
+> If you choose MongoDB as the [database provider](/docs/installation.md#prerequisite), **the `id` property will be added to the response**. See [issue #308](https://github.com/fityannugroho/idn-area/issues/308).
+>
+> _This `id` property is **not present** if you use MySQL or PostgreSQL as the database provider._
 
 ## Getting Started
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,6 +4,7 @@
 
 - [Prerequisite](#prerequisite)
 - [Installation Steps](#installation-steps)
+  - [Installation with Docker](#installation-with-docker)
 - [Run the Test](#run-the-test)
 
 ---
@@ -18,45 +19,46 @@
 
 1. Clone the repository
 
-    Use [`git clone`](https://www.git-scm.com/docs/git-clone) command, to clone this repository using HTTPS or SSH.
+   Use [`git clone`](https://www.git-scm.com/docs/git-clone) command, to clone this repository using HTTPS or SSH.
 
 1. Install the dependencies
 
-    Use `npm install` command, to install all the dependencies.
+   Use `npm install` command, to install all the dependencies.
 
 1. Configure the environment variables
 
-    - Create `.env` file by simply copying the **`.env.example` file** and rename it.
+   - Create `.env` file by simply copying the **`.env.example` file** and rename it.
 
-    - Set the `APP_HOST` and `APP_PORT`.
+   - Set the `APP_HOST` and `APP_PORT`.
 
-    - You can enable [rate limiting](https://docs.nestjs.com/security/rate-limiting) by setting the **`APP_ENABLE_THROTTLE`** to be `true`. You also can customize the `APP_THROTTLE_TTL` and `APP_THROTTLE_LIMIT` as desired.
+   - You can enable [rate limiting](https://docs.nestjs.com/security/rate-limiting) by setting the **`APP_ENABLE_THROTTLE`** to be `true`. You also can customize the `APP_THROTTLE_TTL` and `APP_THROTTLE_LIMIT` as desired.
 
-    - You can also customize the pagination feature by setting the **`APP_PAGINATION_MAX_PAGE_SIZE`** and **`APP_PAGINATION_DEFAULT_PAGE_SIZE`**.
+   - You can also customize the pagination feature by setting the **`APP_PAGINATION_MAX_PAGE_SIZE`** and **`APP_PAGINATION_DEFAULT_PAGE_SIZE`**.
 
-      > [!NOTE]
-      > Set the `APP_PAGINATION_MAX_PAGE_SIZE` value wisely, as it will determine the amount of resource usage (the size of queries to the database).
+     > **Note!**
+     >
+     > Set the `APP_PAGINATION_MAX_PAGE_SIZE` value wisely, as it will determine the amount of resource usage (the size of queries to the database).
 
-    - Set the `DB_PROVIDER` with the data source provider you want to use. Current supported providers: 'mongodb', 'postgresql', and 'mysql'. See the details [here](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#fields).
+   - Set the `DB_PROVIDER` with the data source provider you want to use. Current supported providers: 'mongodb', 'postgresql', and 'mysql'. See the details [here](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#fields).
 
-    - Set the `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD`, `DB_USERNAME`, and `DB_PASSWORD`. See the [connection string](https://pris.ly/d/connection-strings) documentation.
+   - Set the `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD`, `DB_USERNAME`, and `DB_PASSWORD`. See the [connection string](https://pris.ly/d/connection-strings) documentation.
 
-      > If you use local database, you must grant **read-write access** to the database.
+     > If you use local database, you must grant **read-write access** to the database.
 
 1. Generate the database
 
-    Run **`npm run db:migrate`** command to generate the database.
+   Run **`npm run db:migrate`** command to generate the database.
 
-    > You can use `npx prisma migrate deploy` command to run migration in **non-development environments** and if you are using any database providers **other than MongoDB**.
-    > See the details [here](https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-deploy).
+   > You can use `npx prisma migrate deploy` command to run migration in **non-development environments** and if you are using any database providers **other than MongoDB**.
+   > See the details [here](https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-deploy).
 
 1. Seed the data
 
-    Run **`npm run db:seed`** command to seed the data.
+   Run **`npm run db:seed`** command to seed the data.
 
 1. Run the app
 
-    Use `npm run start` command, to run the app.
+   Use `npm run start` command, to run the app.
 
 ### Installation with Docker
 

--- a/src/common/interceptor/paginate.interceptor.ts
+++ b/src/common/interceptor/paginate.interceptor.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { isDBProvider } from '../../../common/utils/db/provider';
 import {
   TransformInterceptor,
   TransformedResponse,
@@ -28,14 +27,6 @@ export class PaginateInterceptor<T> extends TransformInterceptor<
   PaginatedResponse<T>
 > {
   protected transformValue({ data, meta }: PaginatedReturn<T>) {
-    // Remove the `id` property from the data if the database provider is MongoDB.
-    if (isDBProvider('mongodb')) {
-      data = (data as any[]).map(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        ({ id, ...item }) => ({ id: undefined, ...item }) as T,
-      );
-    }
-
     return { data, meta: { pagination: meta } };
   }
 }

--- a/src/common/interceptor/transform.interceptor.ts
+++ b/src/common/interceptor/transform.interceptor.ts
@@ -7,7 +7,6 @@ import {
 import { Reflector } from '@nestjs/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { isDBProvider } from '../../../common/utils/db/provider';
 
 export type WrappedData<
   Data,
@@ -41,22 +40,7 @@ export class TransformInterceptor<T, R extends TransformedResponse<T>>
   constructor(private reflector: Reflector) {}
 
   protected transformValue(val: any): WrappedData<T> {
-    const res: WrappedData<T> = isDataWrapped<T>(val) ? val : { data: val };
-
-    // Remove the `id` property from the data if the database provider is MongoDB.
-    if (isDBProvider('mongodb')) {
-      if (Array.isArray(res.data)) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        res.data = res.data.map(({ id, ...item }) => ({
-          id: undefined,
-          ...item,
-        })) as T;
-      } else {
-        delete (res.data as { id: string }).id;
-      }
-    }
-
-    return res;
+    return isDataWrapped<T>(val) ? val : { data: val };
   }
 
   intercept(context: ExecutionContext, next: CallHandler<T>): Observable<R> {

--- a/test/district.e2e-spec.ts
+++ b/test/district.e2e-spec.ts
@@ -5,7 +5,7 @@ import {
   provinceRegex,
   regencyRegex,
 } from './helper/data-regex';
-import { getEncodedSymbols } from './helper/utils';
+import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
 
 describe('District (e2e)', () => {
   const baseUrl = '/districts';
@@ -23,11 +23,13 @@ describe('District (e2e)', () => {
       const districts = await tester.expectData<District[]>(baseUrl);
 
       districts.forEach((district) => {
-        expect(district).toEqual({
-          code: expect.stringMatching(districtRegex.code),
-          name: expect.stringMatching(districtRegex.name),
-          regencyCode: district.code.slice(0, 4),
-        });
+        expect(district).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(districtRegex.code),
+            name: expect.stringMatching(districtRegex.name),
+            regencyCode: district.code.slice(0, 4),
+          }),
+        );
       });
     });
 
@@ -64,11 +66,13 @@ describe('District (e2e)', () => {
       );
 
       districts.forEach((district) => {
-        expect(district).toEqual({
-          code: expect.stringMatching(districtRegex.code),
-          name: expect.stringMatching(new RegExp(testName, 'i')),
-          regencyCode: district.code.slice(0, 4),
-        });
+        expect(district).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(districtRegex.code),
+            name: expect.stringMatching(new RegExp(testName, 'i')),
+            regencyCode: district.code.slice(0, 4),
+          }),
+        );
       });
     });
 
@@ -79,11 +83,13 @@ describe('District (e2e)', () => {
       );
 
       districts.forEach((district) => {
-        expect(district).toEqual({
-          code: expect.stringMatching(districtRegex.code),
-          name: expect.stringMatching(districtRegex.name),
-          regencyCode,
-        });
+        expect(district).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(districtRegex.code),
+            name: expect.stringMatching(districtRegex.name),
+            regencyCode,
+          }),
+        );
       });
     });
   });
@@ -105,22 +111,24 @@ describe('District (e2e)', () => {
         `${baseUrl}/${testCode}`,
       );
 
-      expect(district).toEqual({
-        code: testCode,
-        name: expect.stringMatching(districtRegex.name),
-        regencyCode: testCode.slice(0, 4),
-        parent: {
-          regency: {
-            code: testCode.slice(0, 4),
-            name: expect.stringMatching(regencyRegex.name),
-            provinceCode: testCode.slice(0, 2),
+      expect(district).toEqual(
+        expectIdFromMongo({
+          code: testCode,
+          name: expect.stringMatching(districtRegex.name),
+          regencyCode: testCode.slice(0, 4),
+          parent: {
+            regency: expectIdFromMongo({
+              code: testCode.slice(0, 4),
+              name: expect.stringMatching(regencyRegex.name),
+              provinceCode: testCode.slice(0, 2),
+            }),
+            province: expectIdFromMongo({
+              code: testCode.slice(0, 2),
+              name: expect.stringMatching(provinceRegex.name),
+            }),
           },
-          province: {
-            code: testCode.slice(0, 2),
-            name: expect.stringMatching(provinceRegex.name),
-          },
-        },
-      });
+        }),
+      );
     });
   });
 

--- a/test/helper/utils.ts
+++ b/test/helper/utils.ts
@@ -1,3 +1,5 @@
+import { isDBProvider } from '@common/utils/db/provider';
+
 /**
  * All symbol characters.
  */
@@ -23,4 +25,16 @@ export function getEncodedSymbols(
     .split('')
     .filter((char) => !exclude.includes(char))
     .map((char) => encodeURIComponent(char));
+}
+
+/**
+ * Expect the data contains the `id` property if the database provider is MongoDB.
+ */
+export function expectIdFromMongo(data: Record<keyof any, any>) {
+  return {
+    ...data,
+    id: isDBProvider('mongodb')
+      ? expect.stringMatching(/^[0-9a-fA-F]{24}$/)
+      : undefined,
+  };
 }

--- a/test/island.e2e-spec.ts
+++ b/test/island.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Island } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
 import { islandRegex, regencyRegex } from './helper/data-regex';
-import { getEncodedSymbols } from './helper/utils';
+import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
 
 describe('Island (e2e)', () => {
   const baseUrl = '/islands';
@@ -19,16 +19,18 @@ describe('Island (e2e)', () => {
       const islands = await tester.expectData<Island[]>(baseUrl);
 
       islands.forEach((island) => {
-        expect(island).toEqual({
-          code: expect.stringMatching(islandRegex.code),
-          coordinate: expect.stringMatching(islandRegex.coordinate),
-          isOutermostSmall: expect.any(Boolean),
-          isPopulated: expect.any(Boolean),
-          latitude: expect.any(Number),
-          longitude: expect.any(Number),
-          name: expect.stringMatching(islandRegex.name),
-          regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
-        });
+        expect(island).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(islandRegex.code),
+            coordinate: expect.stringMatching(islandRegex.coordinate),
+            isOutermostSmall: expect.any(Boolean),
+            isPopulated: expect.any(Boolean),
+            latitude: expect.any(Number),
+            longitude: expect.any(Number),
+            name: expect.stringMatching(islandRegex.name),
+            regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
+          }),
+        );
       });
     });
 
@@ -65,16 +67,18 @@ describe('Island (e2e)', () => {
       );
 
       islands.forEach((island) => {
-        expect(island).toEqual({
-          code: expect.stringMatching(islandRegex.code),
-          coordinate: expect.stringMatching(islandRegex.coordinate),
-          isOutermostSmall: expect.any(Boolean),
-          isPopulated: expect.any(Boolean),
-          latitude: expect.any(Number),
-          longitude: expect.any(Number),
-          name: expect.stringMatching(new RegExp(testName, 'i')),
-          regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
-        });
+        expect(island).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(islandRegex.code),
+            coordinate: expect.stringMatching(islandRegex.coordinate),
+            isOutermostSmall: expect.any(Boolean),
+            isPopulated: expect.any(Boolean),
+            latitude: expect.any(Number),
+            longitude: expect.any(Number),
+            name: expect.stringMatching(new RegExp(testName, 'i')),
+            regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
+          }),
+        );
       });
     });
 
@@ -85,16 +89,18 @@ describe('Island (e2e)', () => {
       );
 
       islands.forEach((island) => {
-        expect(island).toEqual({
-          code: expect.stringMatching(islandRegex.code),
-          coordinate: expect.stringMatching(islandRegex.coordinate),
-          isOutermostSmall: expect.any(Boolean),
-          isPopulated: expect.any(Boolean),
-          latitude: expect.any(Number),
-          longitude: expect.any(Number),
-          name: expect.stringMatching(islandRegex.name),
-          regencyCode: testRegencyCode,
-        });
+        expect(island).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(islandRegex.code),
+            coordinate: expect.stringMatching(islandRegex.coordinate),
+            isOutermostSmall: expect.any(Boolean),
+            isPopulated: expect.any(Boolean),
+            latitude: expect.any(Number),
+            longitude: expect.any(Number),
+            name: expect.stringMatching(islandRegex.name),
+            regencyCode: testRegencyCode,
+          }),
+        );
       });
     });
 
@@ -104,16 +110,18 @@ describe('Island (e2e)', () => {
       );
 
       islands.forEach((island) => {
-        expect(island).toEqual({
-          code: expect.stringMatching(islandRegex.code),
-          coordinate: expect.stringMatching(islandRegex.coordinate),
-          isOutermostSmall: expect.any(Boolean),
-          isPopulated: expect.any(Boolean),
-          latitude: expect.any(Number),
-          longitude: expect.any(Number),
-          name: expect.stringMatching(islandRegex.name),
-          regencyCode: null,
-        });
+        expect(island).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(islandRegex.code),
+            coordinate: expect.stringMatching(islandRegex.coordinate),
+            isOutermostSmall: expect.any(Boolean),
+            isPopulated: expect.any(Boolean),
+            latitude: expect.any(Number),
+            longitude: expect.any(Number),
+            name: expect.stringMatching(islandRegex.name),
+            regencyCode: null,
+          }),
+        );
       });
     });
   });
@@ -133,29 +141,31 @@ describe('Island (e2e)', () => {
     it('should return the island with the `code`', async () => {
       const island = await tester.expectData<Island>(`${baseUrl}/${testCode}`);
 
-      expect(island).toEqual({
-        code: testCode,
-        coordinate: expect.stringMatching(islandRegex.coordinate),
-        isOutermostSmall: expect.any(Boolean),
-        isPopulated: expect.any(Boolean),
-        latitude: expect.any(Number),
-        longitude: expect.any(Number),
-        name: expect.stringMatching(islandRegex.name),
-        regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
-        parent: {
-          regency: island.regencyCode
-            ? {
-                code: island.regencyCode,
-                name: expect.stringMatching(regencyRegex.name),
-                provinceCode: island.code.slice(0, 2),
-              }
-            : null,
-          province: {
-            code: island.code.slice(0, 2),
-            name: expect.stringMatching(islandRegex.name),
+      expect(island).toEqual(
+        expectIdFromMongo({
+          code: testCode,
+          coordinate: expect.stringMatching(islandRegex.coordinate),
+          isOutermostSmall: expect.any(Boolean),
+          isPopulated: expect.any(Boolean),
+          latitude: expect.any(Number),
+          longitude: expect.any(Number),
+          name: expect.stringMatching(islandRegex.name),
+          regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
+          parent: {
+            regency: island.regencyCode
+              ? expectIdFromMongo({
+                  code: island.regencyCode,
+                  name: expect.stringMatching(regencyRegex.name),
+                  provinceCode: island.code.slice(0, 2),
+                })
+              : null,
+            province: expectIdFromMongo({
+              code: island.code.slice(0, 2),
+              name: expect.stringMatching(islandRegex.name),
+            }),
           },
-        },
-      });
+        }),
+      );
     });
   });
 

--- a/test/province.e2e-spec.ts
+++ b/test/province.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Province } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
 import { provinceRegex } from './helper/data-regex';
-import { getEncodedSymbols } from './helper/utils';
+import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
 
 describe('Province (e2e)', () => {
   const baseUrl = '/provinces';
@@ -26,10 +26,12 @@ describe('Province (e2e)', () => {
       const provinces = await tester.expectData<Province[]>(baseUrl);
 
       provinces.forEach((province) => {
-        expect(province).toEqual({
-          code: expect.stringMatching(provinceRegex.code),
-          name: expect.stringMatching(provinceRegex.name),
-        });
+        expect(province).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(provinceRegex.code),
+            name: expect.stringMatching(provinceRegex.name),
+          }),
+        );
       });
     });
   });
@@ -58,10 +60,12 @@ describe('Province (e2e)', () => {
       );
 
       provinces.forEach((province) => {
-        expect(province).toEqual({
-          code: expect.stringMatching(provinceRegex.code),
-          name: expect.stringMatching(new RegExp(testName, 'i')),
-        });
+        expect(province).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(provinceRegex.code),
+            name: expect.stringMatching(new RegExp(testName, 'i')),
+          }),
+        );
       });
     });
   });
@@ -83,10 +87,12 @@ describe('Province (e2e)', () => {
         `${baseUrl}/${testCode}`,
       );
 
-      expect(province).toEqual({
-        code: testCode,
-        name: expect.stringMatching(provinceRegex.name),
-      });
+      expect(province).toEqual(
+        expectIdFromMongo({
+          code: testCode,
+          name: expect.stringMatching(provinceRegex.name),
+        }),
+      );
     });
   });
 

--- a/test/regency.e2e-spec.ts
+++ b/test/regency.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Regency } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
 import { provinceRegex, regencyRegex } from './helper/data-regex';
-import { getEncodedSymbols } from './helper/utils';
+import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
 
 describe('Regency (e2e)', () => {
   const baseUrl = '/regencies';
@@ -19,11 +19,13 @@ describe('Regency (e2e)', () => {
       const regencies = await tester.expectData<Regency[]>(baseUrl);
 
       regencies.forEach((regency) => {
-        expect(regency).toEqual({
-          code: expect.stringMatching(regencyRegex.code),
-          name: expect.stringMatching(regencyRegex.name),
-          provinceCode: expect.stringMatching(regencyRegex.provinceCode),
-        });
+        expect(regency).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(regencyRegex.code),
+            name: expect.stringMatching(regencyRegex.name),
+            provinceCode: expect.stringMatching(regencyRegex.provinceCode),
+          }),
+        );
       });
     });
 
@@ -57,11 +59,13 @@ describe('Regency (e2e)', () => {
       );
 
       regencies.forEach((regency) => {
-        expect(regency).toEqual({
-          code: expect.stringMatching(regencyRegex.code),
-          name: expect.stringMatching(new RegExp(testName, 'i')),
-          provinceCode: expect.stringMatching(regencyRegex.provinceCode),
-        });
+        expect(regency).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(regencyRegex.code),
+            name: expect.stringMatching(new RegExp(testName, 'i')),
+            provinceCode: expect.stringMatching(regencyRegex.provinceCode),
+          }),
+        );
       });
     });
   });
@@ -83,17 +87,19 @@ describe('Regency (e2e)', () => {
         `${baseUrl}/${testCode}`,
       );
 
-      expect(regency).toEqual({
-        code: testCode,
-        name: expect.stringMatching(regencyRegex.name),
-        provinceCode: testCode.slice(0, 2),
-        parent: expect.objectContaining({
-          province: expect.objectContaining({
-            code: testCode.slice(0, 2),
-            name: expect.stringMatching(provinceRegex.name),
-          }),
+      expect(regency).toEqual(
+        expectIdFromMongo({
+          code: testCode,
+          name: expect.stringMatching(regencyRegex.name),
+          provinceCode: testCode.slice(0, 2),
+          parent: {
+            province: expectIdFromMongo({
+              code: testCode.slice(0, 2),
+              name: expect.stringMatching(provinceRegex.name),
+            }),
+          },
         }),
-      });
+      );
     });
   });
 

--- a/test/village.e2e-spec.ts
+++ b/test/village.e2e-spec.ts
@@ -6,7 +6,7 @@ import {
   regencyRegex,
   villageRegex,
 } from './helper/data-regex';
-import { getEncodedSymbols } from './helper/utils';
+import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
 
 describe('Village (e2e)', () => {
   const baseUrl = '/villages';
@@ -24,11 +24,13 @@ describe('Village (e2e)', () => {
       const villages = await tester.expectData<Village[]>(baseUrl);
 
       villages.forEach((village) => {
-        expect(village).toEqual({
-          code: expect.stringMatching(villageRegex.code),
-          name: expect.stringMatching(villageRegex.name),
-          districtCode: village.code.slice(0, 6),
-        });
+        expect(village).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(villageRegex.code),
+            name: expect.stringMatching(villageRegex.name),
+            districtCode: village.code.slice(0, 6),
+          }),
+        );
       });
     });
 
@@ -65,11 +67,13 @@ describe('Village (e2e)', () => {
       );
 
       villages.forEach((village) => {
-        expect(village).toEqual({
-          code: expect.stringMatching(villageRegex.code),
-          name: expect.stringMatching(new RegExp(testName, 'i')),
-          districtCode: village.code.slice(0, 6),
-        });
+        expect(village).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(villageRegex.code),
+            name: expect.stringMatching(new RegExp(testName, 'i')),
+            districtCode: village.code.slice(0, 6),
+          }),
+        );
       });
     });
 
@@ -80,11 +84,13 @@ describe('Village (e2e)', () => {
       );
 
       villages.forEach((village) => {
-        expect(village).toEqual({
-          code: expect.stringMatching(villageRegex.code),
-          name: expect.stringMatching(villageRegex.name),
-          districtCode,
-        });
+        expect(village).toEqual(
+          expectIdFromMongo({
+            code: expect.stringMatching(villageRegex.code),
+            name: expect.stringMatching(villageRegex.name),
+            districtCode,
+          }),
+        );
       });
     });
   });
@@ -106,27 +112,29 @@ describe('Village (e2e)', () => {
         `${baseUrl}/${testCode}`,
       );
 
-      expect(village).toEqual({
-        code: testCode,
-        name: expect.stringMatching(villageRegex.name),
-        districtCode: testCode.slice(0, 6),
-        parent: {
-          district: {
-            code: testCode.slice(0, 6),
-            name: expect.stringMatching(districtRegex.name),
-            regencyCode: testCode.slice(0, 4),
+      expect(village).toEqual(
+        expectIdFromMongo({
+          code: testCode,
+          name: expect.stringMatching(villageRegex.name),
+          districtCode: testCode.slice(0, 6),
+          parent: {
+            district: expectIdFromMongo({
+              code: testCode.slice(0, 6),
+              name: expect.stringMatching(districtRegex.name),
+              regencyCode: testCode.slice(0, 4),
+            }),
+            regency: expectIdFromMongo({
+              code: testCode.slice(0, 4),
+              name: expect.stringMatching(regencyRegex.name),
+              provinceCode: testCode.slice(0, 2),
+            }),
+            province: expectIdFromMongo({
+              code: testCode.slice(0, 2),
+              name: expect.stringMatching(provinceRegex.name),
+            }),
           },
-          regency: {
-            code: testCode.slice(0, 4),
-            name: expect.stringMatching(regencyRegex.name),
-            provinceCode: testCode.slice(0, 2),
-          },
-          province: {
-            code: testCode.slice(0, 2),
-            name: expect.stringMatching(provinceRegex.name),
-          },
-        },
-      });
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [x] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: #308

## What is the new behavior?

- Fix failed end-to-end testing
- Bring back the generated MongoDB `id` to the response. For example:

`GET /villages/1101012001`

```
{
  "statusCode": 200,
  "message": "OK",
  "data": {
    "id": "65dc3d954a0c65806162bd14",
    "code": "1101012001",
    "districtCode": "110101",
    "name": "Keude Bakongan",
    "parent": {
      "district": {
        "id": "65dc3d884a0c658061625e44",
        "code": "110101",
        "name": "Bakongan",
        "regencyCode": "1101"
      },
      "regency": {
        "id": "65dc3d874a0c658061625c42",
        "code": "1101",
        "name": "KABUPATEN ACEH SELATAN",
        "provinceCode": "11"
      },
      "province": {
        "id": "65dc3d864a0c658061625c1c",
        "code": "11",
        "name": "ACEH"
      }
    }
  }
}
```

## Other information

Will resolve #308 
