### PR TITLE
Update `@nestjs/swagger` to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.8",
     "@nestjs/platform-fastify": "^10.4.8",
-    "@nestjs/swagger": "^7.4.2",
+    "@nestjs/swagger": "^8.0.7",
     "@nestjs/throttler": "^6.2.1",
     "@prisma/client": "^5.22.0",
     "class-transformer": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^10.4.8
         version: 10.4.8(@fastify/static@7.0.4)(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.8(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))
       '@nestjs/swagger':
-        specifier: ^7.4.2
-        version: 7.4.2(@fastify/static@7.0.4)(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.8(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+        specifier: ^8.0.7
+        version: 8.0.7(@fastify/static@7.0.4)(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.8(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/throttler':
         specifier: ^6.2.1
         version: 6.2.1(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.8(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)
@@ -611,8 +611,8 @@ packages:
       '@nestjs/websockets':
         optional: true
 
-  '@nestjs/mapped-types@2.0.5':
-    resolution: {integrity: sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==}
+  '@nestjs/mapped-types@2.0.6':
+    resolution: {integrity: sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==}
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
       class-transformer: ^0.4.0 || ^0.5.0
@@ -642,8 +642,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.2'
 
-  '@nestjs/swagger@7.4.2':
-    resolution: {integrity: sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==}
+  '@nestjs/swagger@8.0.7':
+    resolution: {integrity: sha512-zaTMCEZ/CxX7QYF110nTqJsn7eCXp4VI9kv7+AdUcIlBmhhgJpggBw2Mx2p6xVjyz1EoWXGfxxWKnxEyaQwFlg==}
     peerDependencies:
       '@fastify/static': ^6.0.0 || ^7.0.0
       '@nestjs/common': ^9.0.0 || ^10.0.0
@@ -810,6 +810,9 @@ packages:
     resolution: {integrity: sha512-vliZLrDmYKyaUoMzEbMTg2JkerfBjn03KmAw9CykO0Zzkzoyd7o3iZNam/TpyWNjNT+Cz2iO3P9Smv2wgrR+Eg==}
     cpu: [x64]
     os: [win32]
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@swc/core-darwin-arm64@1.9.2':
     resolution: {integrity: sha512-nETmsCoY29krTF2PtspEgicb3tqw7Ci5sInTI03EU5zpqYbPjoPH99BVTjj0OsF53jP5MxwnLI5Hm21lUn1d6A==}
@@ -2153,8 +2156,8 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
-  swagger-ui-dist@5.17.14:
-    resolution: {integrity: sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==}
+  swagger-ui-dist@5.18.2:
+    resolution: {integrity: sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==}
 
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
@@ -2819,7 +2822,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/mapped-types@2.0.5(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
+  '@nestjs/mapped-types@2.0.6(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       reflect-metadata: 0.2.2
@@ -2852,17 +2855,17 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@7.4.2(@fastify/static@7.0.4)(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.8(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@8.0.7(@fastify/static@7.0.4)(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.8(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@nestjs/common': 10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.8(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/mapped-types': 2.0.5(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+      '@nestjs/mapped-types': 2.0.6(@nestjs/common@10.4.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       js-yaml: 4.1.0
       lodash: 4.17.21
       path-to-regexp: 3.3.0
       reflect-metadata: 0.2.2
-      swagger-ui-dist: 5.17.14
+      swagger-ui-dist: 5.18.2
     optionalDependencies:
       '@fastify/static': 7.0.4
       class-transformer: 0.5.1
@@ -2977,6 +2980,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.27.3':
     optional: true
+
+  '@scarf/scarf@1.4.0': {}
 
   '@swc/core-darwin-arm64@1.9.2':
     optional: true
@@ -4395,7 +4400,9 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  swagger-ui-dist@5.17.14: {}
+  swagger-ui-dist@5.18.2:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   symbol-observable@4.0.0: {}
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,7 +1,6 @@
 import { Controller, Get, HttpStatus } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
-@ApiTags('Home')
 @Controller()
 export class AppController {
   @Get()

--- a/src/district/district.controller.ts
+++ b/src/district/district.controller.ts
@@ -11,7 +11,6 @@ import {
   ApiNotFoundResponse,
   ApiOperation,
   ApiQuery,
-  ApiTags,
 } from '@nestjs/swagger';
 import {
   District,
@@ -23,7 +22,6 @@ import { DistrictService } from './district.service';
 import { ApiPaginatedResponse } from '@/common/decorator/api-paginated-response.decorator';
 import { PaginatedReturn } from '@/common/interceptor/paginate.interceptor';
 
-@ApiTags('District')
 @Controller('districts')
 export class DistrictController {
   constructor(private readonly districtService: DistrictService) {}

--- a/src/island/island.controller.ts
+++ b/src/island/island.controller.ts
@@ -11,7 +11,6 @@ import {
   ApiNotFoundResponse,
   ApiOperation,
   ApiQuery,
-  ApiTags,
 } from '@nestjs/swagger';
 import {
   Island,
@@ -23,14 +22,11 @@ import { IslandService } from './island.service';
 import { ApiPaginatedResponse } from '@/common/decorator/api-paginated-response.decorator';
 import { PaginatedReturn } from '@/common/interceptor/paginate.interceptor';
 
-@ApiTags('Island')
 @Controller('islands')
 export class IslandController {
   constructor(private readonly islandService: IslandService) {}
 
-  @ApiOperation({
-    description: 'Get the islands.',
-  })
+  @ApiOperation({ description: 'Get the islands.' })
   @ApiQuery({
     name: 'sortBy',
     description: 'Sort islands by its code, name, or coordinate.',

--- a/src/province/province.controller.ts
+++ b/src/province/province.controller.ts
@@ -11,7 +11,6 @@ import {
   ApiNotFoundResponse,
   ApiOperation,
   ApiQuery,
-  ApiTags,
 } from '@nestjs/swagger';
 import {
   Province,
@@ -22,7 +21,6 @@ import { ProvinceService } from './province.service';
 import { PaginatedReturn } from '@/common/interceptor/paginate.interceptor';
 import { ApiPaginatedResponse } from '@/common/decorator/api-paginated-response.decorator';
 
-@ApiTags('Province')
 @Controller('provinces')
 export class ProvinceController {
   constructor(private readonly provinceService: ProvinceService) {}

--- a/src/regency/regency.controller.ts
+++ b/src/regency/regency.controller.ts
@@ -12,7 +12,6 @@ import {
   ApiNotFoundResponse,
   ApiOperation,
   ApiQuery,
-  ApiTags,
 } from '@nestjs/swagger';
 import {
   Regency,
@@ -23,7 +22,6 @@ import {
 import { RegencyService } from './regency.service';
 import { PaginatedReturn } from '@/common/interceptor/paginate.interceptor';
 
-@ApiTags('Regency')
 @Controller('regencies')
 export class RegencyController {
   constructor(private readonly regencyService: RegencyService) {}

--- a/src/village/village.controller.ts
+++ b/src/village/village.controller.ts
@@ -11,7 +11,6 @@ import {
   ApiNotFoundResponse,
   ApiOperation,
   ApiQuery,
-  ApiTags,
 } from '@nestjs/swagger';
 import {
   Village,
@@ -23,7 +22,6 @@ import { VillageService } from './village.service';
 import { ApiPaginatedResponse } from '@/common/decorator/api-paginated-response.decorator';
 import { PaginatedReturn } from '@/common/interceptor/paginate.interceptor';
 
-@ApiTags('Village')
 @Controller('villages')
 export class VillageController {
   constructor(private readonly villageService: VillageService) {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [x] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

## What is the new behavior?

This pull request includes several updates and improvements to the project dependencies and codebase, primarily focusing on upgrading package versions and removing unused decorators. The most important changes include upgrading `@nestjs/swagger` and `swagger-ui-dist`, as well as removing the `@ApiTags` decorator from various controllers.

> `@ApiTags` now use controller name by default (https://github.com/nestjs/swagger/issues/3011)

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L40-R40): Upgraded `@nestjs/swagger` from version `7.4.2` to `8.0.7`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27-R28): Upgraded `@nestjs/swagger` from version `7.4.2` to `8.0.7` and `swagger-ui-dist` from version `5.17.14` to `5.18.2`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL645-R646) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2156-R2160) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2855-R2868) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4398-R4405)

Codebase simplification:

* [`src/app.controller.ts`](diffhunk://#diff-ef0ff0ca9442bda67ad0810654d636991173ecd7c1abcd6da09288b8815759ffL2-L4): Removed the `@ApiTags` decorator.
* [`src/district/district.controller.ts`](diffhunk://#diff-c0f6cebf4a82bc995edfd78af152431e265f2a5978fb75fd968c75665c8678f6L14): Removed the `@ApiTags` decorator. [[1]](diffhunk://#diff-c0f6cebf4a82bc995edfd78af152431e265f2a5978fb75fd968c75665c8678f6L14) [[2]](diffhunk://#diff-c0f6cebf4a82bc995edfd78af152431e265f2a5978fb75fd968c75665c8678f6L26)
* [`src/island/island.controller.ts`](diffhunk://#diff-4a0ed513a7410740183985a5671273c22b71f7240a25ccb0f3a1f698ec5f550aL14): Removed the `@ApiTags` decorator. [[1]](diffhunk://#diff-4a0ed513a7410740183985a5671273c22b71f7240a25ccb0f3a1f698ec5f550aL14) [[2]](diffhunk://#diff-4a0ed513a7410740183985a5671273c22b71f7240a25ccb0f3a1f698ec5f550aL26-R29)
* [`src/province/province.controller.ts`](diffhunk://#diff-c88f39041bd46d20041498cfc7863fffaf684bcd40b3ad3afec6a8846eb90c63L14): Removed the `@ApiTags` decorator. [[1]](diffhunk://#diff-c88f39041bd46d20041498cfc7863fffaf684bcd40b3ad3afec6a8846eb90c63L14) [[2]](diffhunk://#diff-c88f39041bd46d20041498cfc7863fffaf684bcd40b3ad3afec6a8846eb90c63L25)
* [`src/regency/regency.controller.ts`](diffhunk://#diff-57e156b2357eb2a229b9fcaf2975f2ad77ad669061cd1c6eeecdb109137bfb0fL15): Removed the `@ApiTags` decorator. [[1]](diffhunk://#diff-57e156b2357eb2a229b9fcaf2975f2ad77ad669061cd1c6eeecdb109137bfb0fL15) [[2]](diffhunk://#diff-57e156b2357eb2a229b9fcaf2975f2ad77ad669061cd1c6eeecdb109137bfb0fL26)
* [`src/village/village.controller.ts`](diffhunk://#diff-5fe64e0e2abeee96510be724ab6674d1225aa8eb5ffaba2ba61089ed455effb4L14): Removed the `@ApiTags` decorator. [[1]](diffhunk://#diff-5fe64e0e2abeee96510be724ab6674d1225aa8eb5ffaba2ba61089ed455effb4L14) [[2]](diffhunk://#diff-5fe64e0e2abeee96510be724ab6674d1225aa8eb5ffaba2ba61089ed455effb4L26)

## Other information
None
