### PR TITLE
Mongo schema changes

### DIFF
--- a/prisma/mongodb/schema.prisma
+++ b/prisma/mongodb/schema.prisma
@@ -8,8 +8,7 @@ datasource db {
 }
 
 model District {
-  id          String    @id @default(auto()) @map("_id") @db.ObjectId
-  code        String    @unique
+  code        String    @id @map("_id")
   name        String
   regencyCode String    @map("regency_code")
   regency     Regency   @relation(fields: [regencyCode], references: [code])
@@ -19,8 +18,7 @@ model District {
 }
 
 model Island {
-  id               String   @id @default(auto()) @map("_id") @db.ObjectId
-  code             String   @unique
+  code             String   @id @map("_id")
   coordinate       String
   isOutermostSmall Boolean  @map("is_outermost_small")
   isPopulated      Boolean  @map("is_populated")
@@ -32,8 +30,7 @@ model Island {
 }
 
 model Province {
-  id        String    @id @default(auto()) @map("_id") @db.ObjectId
-  code      String    @unique
+  code      String @id @map("_id")
   name      String
   regencies Regency[]
 
@@ -41,8 +38,7 @@ model Province {
 }
 
 model Regency {
-  id           String     @id @default(auto()) @map("_id") @db.ObjectId
-  code         String     @unique
+  code         String     @id @map("_id")
   name         String
   provinceCode String     @map("province_code")
   islands      Island[]
@@ -61,8 +57,7 @@ model SeederLogs {
 }
 
 model Village {
-  id           String   @id @default(auto()) @map("_id") @db.ObjectId
-  code         String   @unique
+  code         String   @id @map("_id")
   districtCode String   @map("district_code")
   name         String
   district     District @relation(fields: [districtCode], references: [code])

--- a/src/district/district.service.spec.ts
+++ b/src/district/district.service.spec.ts
@@ -183,7 +183,6 @@ describe('DistrictService', () => {
         .spyOn(prismaService.district, 'findUnique')
         .mockResolvedValue({
           ...expectedDistrict,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
           regency: {
             ...expectedRegency,

--- a/src/island/island.service.spec.ts
+++ b/src/island/island.service.spec.ts
@@ -235,7 +235,6 @@ describe('IslandService', () => {
         .spyOn(prismaService.island, 'findUnique')
         .mockResolvedValue({
           ...expectedIsland,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
           regency: { ...expectedRegency, province: expectedProvince },
         });
@@ -268,7 +267,6 @@ describe('IslandService', () => {
         .spyOn(prismaService.island, 'findUnique')
         .mockResolvedValue({
           ...expectedIsland,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
           regency: null,
         });

--- a/src/regency/regency.service.spec.ts
+++ b/src/regency/regency.service.spec.ts
@@ -161,7 +161,6 @@ describe('RegencyService', () => {
         .spyOn(prismaService.regency, 'findUnique')
         .mockReturnValue({
           ...expectedRegency,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
           province: expectedProvince,
         });

--- a/src/village/village.service.spec.ts
+++ b/src/village/village.service.spec.ts
@@ -194,7 +194,6 @@ describe('VillageService', () => {
         .spyOn(prismaService.village, 'findUnique')
         .mockResolvedValue({
           ...expectedVillage,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
           district: {
             ...expectedDistrict,

--- a/test/district.e2e-spec.ts
+++ b/test/district.e2e-spec.ts
@@ -5,7 +5,7 @@ import {
   provinceRegex,
   regencyRegex,
 } from './helper/data-regex';
-import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
+import { getEncodedSymbols } from './helper/utils';
 
 describe('District (e2e)', () => {
   const baseUrl = '/districts';
@@ -23,13 +23,11 @@ describe('District (e2e)', () => {
       const districts = await tester.expectData<District[]>(baseUrl);
 
       for (const district of districts) {
-        expect(district).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(districtRegex.code),
-            name: expect.stringMatching(districtRegex.name),
-            regencyCode: district.code.slice(0, 4),
-          }),
-        );
+        expect(district).toEqual({
+          code: expect.stringMatching(districtRegex.code),
+          name: expect.stringMatching(districtRegex.name),
+          regencyCode: district.code.slice(0, 4),
+        });
       }
     });
 
@@ -66,13 +64,11 @@ describe('District (e2e)', () => {
       );
 
       for (const district of districts) {
-        expect(district).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(districtRegex.code),
-            name: expect.stringMatching(new RegExp(testName, 'i')),
-            regencyCode: district.code.slice(0, 4),
-          }),
-        );
+        expect(district).toEqual({
+          code: expect.stringMatching(districtRegex.code),
+          name: expect.stringMatching(new RegExp(testName, 'i')),
+          regencyCode: district.code.slice(0, 4),
+        });
       }
     });
 
@@ -83,13 +79,11 @@ describe('District (e2e)', () => {
       );
 
       for (const district of districts) {
-        expect(district).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(districtRegex.code),
-            name: expect.stringMatching(districtRegex.name),
-            regencyCode,
-          }),
-        );
+        expect(district).toEqual({
+          code: expect.stringMatching(districtRegex.code),
+          name: expect.stringMatching(districtRegex.name),
+          regencyCode,
+        });
       }
     });
   });
@@ -111,24 +105,22 @@ describe('District (e2e)', () => {
         `${baseUrl}/${testCode}`,
       );
 
-      expect(district).toEqual(
-        expectIdFromMongo({
-          code: testCode,
-          name: expect.stringMatching(districtRegex.name),
-          regencyCode: testCode.slice(0, 4),
-          parent: {
-            regency: expectIdFromMongo({
-              code: testCode.slice(0, 4),
-              name: expect.stringMatching(regencyRegex.name),
-              provinceCode: testCode.slice(0, 2),
-            }),
-            province: expectIdFromMongo({
-              code: testCode.slice(0, 2),
-              name: expect.stringMatching(provinceRegex.name),
-            }),
+      expect(district).toEqual({
+        code: testCode,
+        name: expect.stringMatching(districtRegex.name),
+        regencyCode: testCode.slice(0, 4),
+        parent: {
+          regency: {
+            code: testCode.slice(0, 4),
+            name: expect.stringMatching(regencyRegex.name),
+            provinceCode: testCode.slice(0, 2),
           },
-        }),
-      );
+          province: {
+            code: testCode.slice(0, 2),
+            name: expect.stringMatching(provinceRegex.name),
+          },
+        },
+      });
     });
   });
 

--- a/test/helper/data-regex.ts
+++ b/test/helper/data-regex.ts
@@ -4,33 +4,33 @@ type DataRegex<T extends Record<string | number | symbol, unknown>> = Partial<
   Record<keyof T, RegExp>
 >;
 
-export const provinceRegex: DataRegex<Province> = {
+export const provinceRegex = {
   code: /^\d{2}$/,
   name: /^(?!\s)(?!PROVINSI)[A-Z ]+$/,
-};
+} as const satisfies DataRegex<Province>;
 
-export const regencyRegex: DataRegex<Regency> = {
+export const regencyRegex = {
   code: /^\d{4}$/,
   name: /^(?:KABUPATEN|KOTA)[A-Z ]+$/,
   provinceCode: provinceRegex.code,
-};
+} as const satisfies DataRegex<Regency>;
 
-export const districtRegex: DataRegex<District> = {
+export const districtRegex = {
   code: /^\d{6}$/,
   name: /^[a-zA-Z0-9\-'.\\/() ]+$/,
   regencyCode: regencyRegex.code,
-};
+} as const satisfies DataRegex<District>;
 
-export const villageRegex: DataRegex<Village> = {
+export const villageRegex = {
   code: /^\d{10}$/,
   name: /^[a-zA-Z0-9\-'"’.*\\/() ]+$/,
   districtCode: districtRegex.code,
-};
+} as const satisfies DataRegex<Village>;
 
-export const islandRegex: DataRegex<Island> = {
+export const islandRegex = {
   code: /^\d{9}$/,
   name: /^[a-zA-Z0-9\-'/ ]+$/,
   coordinate:
     /^([0-8][0-9]|90)°([0-5][0-9]|60)'(([0-5][0-9].[0-9]{2})|60.00)"\s(N|S)\s(0\d{2}|1([0-7][0-9]|80))°([0-5][0-9]|60)'(([0-5][0-9].[0-9]{2})|60.00)"\s(E|W)$/,
   regencyCode: /^\d{4}|$/,
-};
+} as const satisfies DataRegex<Island>;

--- a/test/helper/utils.ts
+++ b/test/helper/utils.ts
@@ -1,5 +1,3 @@
-import { isDBProvider } from '@/common/utils/db/provider';
-
 /**
  * All symbol characters.
  */
@@ -25,16 +23,4 @@ export function getEncodedSymbols(
     .split('')
     .filter((char) => !exclude.includes(char))
     .map((char) => encodeURIComponent(char));
-}
-
-/**
- * Expect the data contains the `id` property if the database provider is MongoDB.
- */
-export function expectIdFromMongo(data: Record<keyof any, any>) {
-  return {
-    ...data,
-    id: isDBProvider('mongodb')
-      ? expect.stringMatching(/^[0-9a-fA-F]{24}$/)
-      : undefined,
-  };
 }

--- a/test/island.e2e-spec.ts
+++ b/test/island.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Island } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
 import { islandRegex, regencyRegex } from './helper/data-regex';
-import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
+import { getEncodedSymbols } from './helper/utils';
 
 describe('Island (e2e)', () => {
   const baseUrl = '/islands';
@@ -19,18 +19,16 @@ describe('Island (e2e)', () => {
       const islands = await tester.expectData<Island[]>(baseUrl);
 
       for (const island of islands) {
-        expect(island).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(islandRegex.code),
-            coordinate: expect.stringMatching(islandRegex.coordinate),
-            isOutermostSmall: expect.any(Boolean),
-            isPopulated: expect.any(Boolean),
-            latitude: expect.any(Number),
-            longitude: expect.any(Number),
-            name: expect.stringMatching(islandRegex.name),
-            regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
-          }),
-        );
+        expect(island).toEqual({
+          code: expect.stringMatching(islandRegex.code),
+          coordinate: expect.stringMatching(islandRegex.coordinate),
+          isOutermostSmall: expect.any(Boolean),
+          isPopulated: expect.any(Boolean),
+          latitude: expect.any(Number),
+          longitude: expect.any(Number),
+          name: expect.stringMatching(islandRegex.name),
+          regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
+        });
       }
     });
 
@@ -67,18 +65,16 @@ describe('Island (e2e)', () => {
       );
 
       for (const island of islands) {
-        expect(island).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(islandRegex.code),
-            coordinate: expect.stringMatching(islandRegex.coordinate),
-            isOutermostSmall: expect.any(Boolean),
-            isPopulated: expect.any(Boolean),
-            latitude: expect.any(Number),
-            longitude: expect.any(Number),
-            name: expect.stringMatching(new RegExp(testName, 'i')),
-            regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
-          }),
-        );
+        expect(island).toEqual({
+          code: expect.stringMatching(islandRegex.code),
+          coordinate: expect.stringMatching(islandRegex.coordinate),
+          isOutermostSmall: expect.any(Boolean),
+          isPopulated: expect.any(Boolean),
+          latitude: expect.any(Number),
+          longitude: expect.any(Number),
+          name: expect.stringMatching(new RegExp(testName, 'i')),
+          regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
+        });
       }
     });
 
@@ -89,18 +85,16 @@ describe('Island (e2e)', () => {
       );
 
       for (const island of islands) {
-        expect(island).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(islandRegex.code),
-            coordinate: expect.stringMatching(islandRegex.coordinate),
-            isOutermostSmall: expect.any(Boolean),
-            isPopulated: expect.any(Boolean),
-            latitude: expect.any(Number),
-            longitude: expect.any(Number),
-            name: expect.stringMatching(islandRegex.name),
-            regencyCode: testRegencyCode,
-          }),
-        );
+        expect(island).toEqual({
+          code: expect.stringMatching(islandRegex.code),
+          coordinate: expect.stringMatching(islandRegex.coordinate),
+          isOutermostSmall: expect.any(Boolean),
+          isPopulated: expect.any(Boolean),
+          latitude: expect.any(Number),
+          longitude: expect.any(Number),
+          name: expect.stringMatching(islandRegex.name),
+          regencyCode: testRegencyCode,
+        });
       }
     });
 
@@ -110,18 +104,16 @@ describe('Island (e2e)', () => {
       );
 
       for (const island of islands) {
-        expect(island).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(islandRegex.code),
-            coordinate: expect.stringMatching(islandRegex.coordinate),
-            isOutermostSmall: expect.any(Boolean),
-            isPopulated: expect.any(Boolean),
-            latitude: expect.any(Number),
-            longitude: expect.any(Number),
-            name: expect.stringMatching(islandRegex.name),
-            regencyCode: null,
-          }),
-        );
+        expect(island).toEqual({
+          code: expect.stringMatching(islandRegex.code),
+          coordinate: expect.stringMatching(islandRegex.coordinate),
+          isOutermostSmall: expect.any(Boolean),
+          isPopulated: expect.any(Boolean),
+          latitude: expect.any(Number),
+          longitude: expect.any(Number),
+          name: expect.stringMatching(islandRegex.name),
+          regencyCode: null,
+        });
       }
     });
   });
@@ -141,31 +133,29 @@ describe('Island (e2e)', () => {
     it('should return the island with the `code`', async () => {
       const island = await tester.expectData<Island>(`${baseUrl}/${testCode}`);
 
-      expect(island).toEqual(
-        expectIdFromMongo({
-          code: testCode,
-          coordinate: expect.stringMatching(islandRegex.coordinate),
-          isOutermostSmall: expect.any(Boolean),
-          isPopulated: expect.any(Boolean),
-          latitude: expect.any(Number),
-          longitude: expect.any(Number),
-          name: expect.stringMatching(islandRegex.name),
-          regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
-          parent: {
-            regency: island.regencyCode
-              ? expectIdFromMongo({
-                  code: island.regencyCode,
-                  name: expect.stringMatching(regencyRegex.name),
-                  provinceCode: island.code.slice(0, 2),
-                })
-              : null,
-            province: expectIdFromMongo({
-              code: island.code.slice(0, 2),
-              name: expect.stringMatching(islandRegex.name),
-            }),
+      expect(island).toEqual({
+        code: testCode,
+        coordinate: expect.stringMatching(islandRegex.coordinate),
+        isOutermostSmall: expect.any(Boolean),
+        isPopulated: expect.any(Boolean),
+        latitude: expect.any(Number),
+        longitude: expect.any(Number),
+        name: expect.stringMatching(islandRegex.name),
+        regencyCode: island.regencyCode ? island.code.slice(0, 4) : null,
+        parent: {
+          regency: island.regencyCode
+            ? {
+                code: island.regencyCode,
+                name: expect.stringMatching(regencyRegex.name),
+                provinceCode: island.code.slice(0, 2),
+              }
+            : null,
+          province: {
+            code: island.code.slice(0, 2),
+            name: expect.stringMatching(islandRegex.name),
           },
-        }),
-      );
+        },
+      });
     });
   });
 

--- a/test/province.e2e-spec.ts
+++ b/test/province.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Province } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
 import { provinceRegex } from './helper/data-regex';
-import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
+import { getEncodedSymbols } from './helper/utils';
 
 describe('Province (e2e)', () => {
   const baseUrl = '/provinces';
@@ -26,12 +26,10 @@ describe('Province (e2e)', () => {
       const provinces = await tester.expectData<Province[]>(baseUrl);
 
       for (const province of provinces) {
-        expect(province).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(provinceRegex.code),
-            name: expect.stringMatching(provinceRegex.name),
-          }),
-        );
+        expect(province).toEqual({
+          code: expect.stringMatching(provinceRegex.code),
+          name: expect.stringMatching(provinceRegex.name),
+        });
       }
     });
   });
@@ -60,12 +58,10 @@ describe('Province (e2e)', () => {
       );
 
       for (const province of provinces) {
-        expect(province).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(provinceRegex.code),
-            name: expect.stringMatching(new RegExp(testName, 'i')),
-          }),
-        );
+        expect(province).toEqual({
+          code: expect.stringMatching(provinceRegex.code),
+          name: expect.stringMatching(new RegExp(testName, 'i')),
+        });
       }
     });
   });
@@ -87,12 +83,10 @@ describe('Province (e2e)', () => {
         `${baseUrl}/${testCode}`,
       );
 
-      expect(province).toEqual(
-        expectIdFromMongo({
-          code: testCode,
-          name: expect.stringMatching(provinceRegex.name),
-        }),
-      );
+      expect(province).toEqual({
+        code: testCode,
+        name: expect.stringMatching(provinceRegex.name),
+      });
     });
   });
 

--- a/test/regency.e2e-spec.ts
+++ b/test/regency.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Regency } from '@prisma/client';
 import { AppTester } from './helper/app-tester';
 import { provinceRegex, regencyRegex } from './helper/data-regex';
-import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
+import { getEncodedSymbols } from './helper/utils';
 
 describe('Regency (e2e)', () => {
   const baseUrl = '/regencies';
@@ -19,13 +19,11 @@ describe('Regency (e2e)', () => {
       const regencies = await tester.expectData<Regency[]>(baseUrl);
 
       for (const regency of regencies) {
-        expect(regency).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(regencyRegex.code),
-            name: expect.stringMatching(regencyRegex.name),
-            provinceCode: expect.stringMatching(regencyRegex.provinceCode),
-          }),
-        );
+        expect(regency).toEqual({
+          code: expect.stringMatching(regencyRegex.code),
+          name: expect.stringMatching(regencyRegex.name),
+          provinceCode: expect.stringMatching(regencyRegex.provinceCode),
+        });
       }
     });
 
@@ -59,13 +57,11 @@ describe('Regency (e2e)', () => {
       );
 
       for (const regency of regencies) {
-        expect(regency).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(regencyRegex.code),
-            name: expect.stringMatching(new RegExp(testName, 'i')),
-            provinceCode: expect.stringMatching(regencyRegex.provinceCode),
-          }),
-        );
+        expect(regency).toEqual({
+          code: expect.stringMatching(regencyRegex.code),
+          name: expect.stringMatching(new RegExp(testName, 'i')),
+          provinceCode: expect.stringMatching(regencyRegex.provinceCode),
+        });
       }
     });
   });
@@ -87,19 +83,17 @@ describe('Regency (e2e)', () => {
         `${baseUrl}/${testCode}`,
       );
 
-      expect(regency).toEqual(
-        expectIdFromMongo({
-          code: testCode,
-          name: expect.stringMatching(regencyRegex.name),
-          provinceCode: testCode.slice(0, 2),
-          parent: {
-            province: expectIdFromMongo({
-              code: testCode.slice(0, 2),
-              name: expect.stringMatching(provinceRegex.name),
-            }),
+      expect(regency).toEqual({
+        code: testCode,
+        name: expect.stringMatching(regencyRegex.name),
+        provinceCode: testCode.slice(0, 2),
+        parent: {
+          province: {
+            code: testCode.slice(0, 2),
+            name: expect.stringMatching(provinceRegex.name),
           },
-        }),
-      );
+        },
+      });
     });
   });
 

--- a/test/village.e2e-spec.ts
+++ b/test/village.e2e-spec.ts
@@ -6,7 +6,7 @@ import {
   regencyRegex,
   villageRegex,
 } from './helper/data-regex';
-import { expectIdFromMongo, getEncodedSymbols } from './helper/utils';
+import { getEncodedSymbols } from './helper/utils';
 
 describe('Village (e2e)', () => {
   const baseUrl = '/villages';
@@ -24,13 +24,11 @@ describe('Village (e2e)', () => {
       const villages = await tester.expectData<Village[]>(baseUrl);
 
       for (const village of villages) {
-        expect(village).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(villageRegex.code),
-            name: expect.stringMatching(villageRegex.name),
-            districtCode: village.code.slice(0, 6),
-          }),
-        );
+        expect(village).toEqual({
+          code: expect.stringMatching(villageRegex.code),
+          name: expect.stringMatching(villageRegex.name),
+          districtCode: village.code.slice(0, 6),
+        });
       }
     });
 
@@ -67,13 +65,11 @@ describe('Village (e2e)', () => {
       );
 
       for (const village of villages) {
-        expect(village).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(villageRegex.code),
-            name: expect.stringMatching(new RegExp(testName, 'i')),
-            districtCode: village.code.slice(0, 6),
-          }),
-        );
+        expect(village).toEqual({
+          code: expect.stringMatching(villageRegex.code),
+          name: expect.stringMatching(new RegExp(testName, 'i')),
+          districtCode: village.code.slice(0, 6),
+        });
       }
     });
 
@@ -84,13 +80,11 @@ describe('Village (e2e)', () => {
       );
 
       for (const village of villages) {
-        expect(village).toEqual(
-          expectIdFromMongo({
-            code: expect.stringMatching(villageRegex.code),
-            name: expect.stringMatching(villageRegex.name),
-            districtCode,
-          }),
-        );
+        expect(village).toEqual({
+          code: expect.stringMatching(villageRegex.code),
+          name: expect.stringMatching(villageRegex.name),
+          districtCode,
+        });
       }
     });
   });
@@ -112,29 +106,27 @@ describe('Village (e2e)', () => {
         `${baseUrl}/${testCode}`,
       );
 
-      expect(village).toEqual(
-        expectIdFromMongo({
-          code: testCode,
-          name: expect.stringMatching(villageRegex.name),
-          districtCode: testCode.slice(0, 6),
-          parent: {
-            district: expectIdFromMongo({
-              code: testCode.slice(0, 6),
-              name: expect.stringMatching(districtRegex.name),
-              regencyCode: testCode.slice(0, 4),
-            }),
-            regency: expectIdFromMongo({
-              code: testCode.slice(0, 4),
-              name: expect.stringMatching(regencyRegex.name),
-              provinceCode: testCode.slice(0, 2),
-            }),
-            province: expectIdFromMongo({
-              code: testCode.slice(0, 2),
-              name: expect.stringMatching(provinceRegex.name),
-            }),
+      expect(village).toEqual({
+        code: testCode,
+        name: expect.stringMatching(villageRegex.name),
+        districtCode: testCode.slice(0, 6),
+        parent: {
+          district: {
+            code: testCode.slice(0, 6),
+            name: expect.stringMatching(districtRegex.name),
+            regencyCode: testCode.slice(0, 4),
           },
-        }),
-      );
+          regency: {
+            code: testCode.slice(0, 4),
+            name: expect.stringMatching(regencyRegex.name),
+            provinceCode: testCode.slice(0, 2),
+          },
+          province: {
+            code: testCode.slice(0, 2),
+            name: expect.stringMatching(provinceRegex.name),
+          },
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [x] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

Issue Number: resolves #469 

## What is the new behavior?
This pull request includes significant changes to the `prisma/mongodb/schema.prisma` file, removing the `id` field from several models and making adjustments to the related tests to reflect this change. Additionally, some utility functions and imports have been removed from the test files.

Schema changes:
* Removed the `id` field from the `District`, `Island`, `Province`, `Regency`, and `Village` models, and made the `code` field the primary identifier instead (`prisma/mongodb/schema.prisma`). [[1]](diffhunk://#diff-2b279e54167552d5ebb3f38fddc9d0ea79d9a329d2284b7e044c9da728447fb4L11-R11) [[2]](diffhunk://#diff-2b279e54167552d5ebb3f38fddc9d0ea79d9a329d2284b7e044c9da728447fb4L22-R21) [[3]](diffhunk://#diff-2b279e54167552d5ebb3f38fddc9d0ea79d9a329d2284b7e044c9da728447fb4L35-R41) [[4]](diffhunk://#diff-2b279e54167552d5ebb3f38fddc9d0ea79d9a329d2284b7e044c9da728447fb4L64-R60)

Test updates:
* Removed the `expectIdFromMongo` utility function and its usage in various test files, simplifying the test assertions (`test/district.e2e-spec.ts`, `test/island.e2e-spec.ts`, `test/province.e2e-spec.ts`, `test/regency.e2e-spec.ts`, `test/village.e2e-spec.ts`). [[1]](diffhunk://#diff-6a021991bdaaaa9c908ef9140825313da771adaeaf283e1a2fefe6f0f2035e16L8-R8) [[2]](diffhunk://#diff-6a021991bdaaaa9c908ef9140825313da771adaeaf283e1a2fefe6f0f2035e16L26-R30) [[3]](diffhunk://#diff-6a021991bdaaaa9c908ef9140825313da771adaeaf283e1a2fefe6f0f2035e16L69-R71) [[4]](diffhunk://#diff-6a021991bdaaaa9c908ef9140825313da771adaeaf283e1a2fefe6f0f2035e16L86-R86) [[5]](diffhunk://#diff-6a021991bdaaaa9c908ef9140825313da771adaeaf283e1a2fefe6f0f2035e16L114-R123) [[6]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L4-R4) [[7]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L22-R22) [[8]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L32-R31) [[9]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L70-R68) [[10]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L80-R77) [[11]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L92-R88) [[12]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L102-R97) [[13]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L113-R107) [[14]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L123-R116) [[15]](diffhunk://#diff-2c86c3af40cb52ef4eba2a5df10989eec771b8b9f9b694041c8889045dfe8631L144-R136) [[16]](diffhunk://#diff-7f7f81539519a94609c8db53221d0ce1cdc9991c1e43dbfa04932ae6860e565fL4-R4) [[17]](diffhunk://#diff-7f7f81539519a94609c8db53221d0ce1cdc9991c1e43dbfa04932ae6860e565fL29-R32) [[18]](diffhunk://#diff-7f7f81539519a94609c8db53221d0ce1cdc9991c1e43dbfa04932ae6860e565fL63-R64) [[19]](diffhunk://#diff-7f7f81539519a94609c8db53221d0ce1cdc9991c1e43dbfa04932ae6860e565fL90-R89) [[20]](diffhunk://#diff-9fe77c6680722ad67e7986ab5fa526e8dc3ee405379dcba1fa466d68c4d70e42L4-R4) [[21]](diffhunk://#diff-9fe77c6680722ad67e7986ab5fa526e8dc3ee405379dcba1fa466d68c4d70e42L22-R26) [[22]](diffhunk://#diff-9fe77c6680722ad67e7986ab5fa526e8dc3ee405379dcba1fa466d68c4d70e42L62-R64) [[23]](diffhunk://#diff-9fe77c6680722ad67e7986ab5fa526e8dc3ee405379dcba1fa466d68c4d70e42L90-R96) [[24]](diffhunk://#diff-3f434f36ff2bf252eb09e4270de9e2da1fff6ccbee653844af7505175978e2b1L9-R9)

Utility function removal:
* Removed the `isDBProvider` import and the `expectIdFromMongo` function from `test/helper/utils.ts` as they are no longer needed. [[1]](diffhunk://#diff-a3aba922bc5283fe9d09dda1ecac5948a1c857437c59fd7a94671691710b4922L1-L2) [[2]](diffhunk://#diff-a3aba922bc5283fe9d09dda1ecac5948a1c857437c59fd7a94671691710b4922L29-L40)

Regex updates:
* Updated the regex definitions in `test/helper/data-regex.ts` to use the `satisfies` keyword to ensure type safety.

## Other information

⚠️ This PR includes BREAKING CHANGES!

If you are using `mongodb` as your database provider, the `_id` property is now removed from the response. Run `pnpm prisma:gen && pnpm db:migrate && pnpm db:seed` to apply the changes.
