### PR TITLE
fix(swagger): correct Swagger schema generation, enable type check on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 /dist
 /node_modules
+/src/metadata.ts
 
 # Logs
 logs

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,6 +4,7 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "builder": "swc",
+    "typeCheck": true,
     "deleteOutDir": true,
     "plugins": ["@nestjs/swagger"]
   }

--- a/prisma/mongodb/seeder.ts
+++ b/prisma/mongodb/seeder.ts
@@ -10,8 +10,8 @@ export class MongodbSeeder extends Seeder {
       island: 'islands',
     };
 
-    // @ts-expect-error Skip TypeScript checking because `$runCommandRaw()` method only available for mongodb provider.
-    const res = await this.prisma.$runCommandRaw({
+    // Bypass TypeScript checking because `$runCommandRaw()` method only available for mongodb provider.
+    const res = await (this.prisma as any).$runCommandRaw({
       delete: mongoCollectionMap[area],
       deletes: [
         {

--- a/src/common/decorator/api-data-response.decorator.ts
+++ b/src/common/decorator/api-data-response.decorator.ts
@@ -64,15 +64,16 @@ export const ApiDataResponse = <Model extends Type<any>>(
                 type: 'array',
                 items: { $ref: getSchemaPath(options.model) },
               }
-            : {
-                type: 'object',
-                $ref: getSchemaPath(options.model),
-              },
+            : { $ref: getSchemaPath(options.model) },
           meta: {
             type: 'object',
-            nullable: options.multiple ? undefined : true,
             properties: {
-              total: options.multiple ? { type: 'number', example: 1 } : {},
+              ...(options.multiple && {
+                total: {
+                  type: 'number',
+                  example: 1,
+                },
+              }),
             },
           },
         },

--- a/src/common/decorator/api-data-response.decorator.ts
+++ b/src/common/decorator/api-data-response.decorator.ts
@@ -39,7 +39,7 @@ type Options<Model extends Type<any>> = {
  * - `statusCode` (number)
  * - `message` (string)
  * - `data` (object or array)
- * - `meta` (object, optional)
+ * - `meta` (object)
  *    - `total` (number, if the `data` is an array)
  *
  * This decorator will also add `ApiExtraModels` and `ApiOkResponse` decorator

--- a/src/common/interceptor/__tests__/transform.interceptor.spec.ts
+++ b/src/common/interceptor/__tests__/transform.interceptor.spec.ts
@@ -90,7 +90,7 @@ describe('TransformInterceptor', () => {
         statusCode: 200,
         message: 'OK',
         data: responseData,
-        meta: undefined,
+        meta: {},
       });
     });
 
@@ -110,7 +110,7 @@ describe('TransformInterceptor', () => {
         statusCode: 200,
         message: customMessage,
         data: responseData,
-        meta: undefined,
+        meta: {},
       });
     });
 
@@ -171,7 +171,7 @@ describe('TransformInterceptor', () => {
         statusCode: 200,
         message: messageArray,
         data: responseData,
-        meta: undefined,
+        meta: {},
       });
     });
 
@@ -198,7 +198,7 @@ describe('TransformInterceptor', () => {
         statusCode: 201,
         message: 'Created',
         data: responseData,
-        meta: undefined,
+        meta: {},
       });
     });
 

--- a/src/common/interceptor/transform.interceptor.ts
+++ b/src/common/interceptor/transform.interceptor.ts
@@ -57,7 +57,7 @@ export class TransformInterceptor<T, R extends TransformedResponse<T>>
 
     return next.handle().pipe(
       map((res) => {
-        const { data, meta } = this.transformValue(res);
+        const { data, meta = {} } = this.transformValue(res);
 
         return {
           statusCode: context.switchToHttp().getResponse().statusCode,

--- a/src/district/district.dto.ts
+++ b/src/district/district.dto.ts
@@ -46,9 +46,15 @@ export class DistrictFindByCodeParams extends PickType(District, [
   'code',
 ] as const) {}
 
+export class DistrictParent {
+  @ApiProperty({ type: () => Regency })
+  regency: Regency;
+
+  @ApiProperty({ type: () => Province })
+  province: Province;
+}
+
 export class DistrictWithParent extends District {
-  parent: {
-    regency: Regency;
-    province: Province;
-  };
+  @ApiProperty({ type: () => DistrictParent })
+  parent: DistrictParent;
 }

--- a/src/island/island.dto.ts
+++ b/src/island/island.dto.ts
@@ -81,9 +81,15 @@ export class IslandFindByCodeParams extends PickType(Island, [
   'code',
 ] as const) {}
 
+export class IslandParent {
+  @ApiProperty({ type: () => Regency, nullable: true })
+  regency: Regency | null;
+
+  @ApiProperty({ type: () => Province })
+  province: Province;
+}
+
 export class IslandWithParent extends Island {
-  parent: {
-    regency?: Regency | null;
-    province: Province;
-  };
+  @ApiProperty({ type: () => IslandParent })
+  parent: IslandParent;
 }

--- a/src/regency/regency.dto.ts
+++ b/src/regency/regency.dto.ts
@@ -49,8 +49,12 @@ export class RegencyFindByCodeParams extends PickType(Regency, [
   'code',
 ] as const) {}
 
+export class RegencyParent {
+  @ApiProperty({ type: () => Province })
+  province: Province;
+}
+
 export class RegencyWithParent extends Regency {
-  parent: {
-    province: Province;
-  };
+  @ApiProperty({ type: () => RegencyParent })
+  parent: RegencyParent;
 }

--- a/src/village/village.dto.ts
+++ b/src/village/village.dto.ts
@@ -50,10 +50,18 @@ export class VillageFindByCodeParams extends PickType(Village, [
   'code',
 ] as const) {}
 
+export class VillageParent {
+  @ApiProperty({ type: () => District })
+  district: District;
+
+  @ApiProperty({ type: () => Regency })
+  regency: Regency;
+
+  @ApiProperty({ type: () => Province })
+  province: Province;
+}
+
 export class VillageWithParent extends Village {
-  parent: {
-    district: District;
-    regency: Regency;
-    province: Province;
-  };
+  @ApiProperty({ type: () => VillageParent })
+  parent: VillageParent;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [ ] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type
What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Swagger (OpenAPI) schema generation produces incorrect or incomplete schemas for some DTOs and controllers, causing mismatches between the documented response (the OpenAPI schema) and the actual responses of the API. This results in unclear API docs and potential validation issues in clients relying on the generated OpenAPI spec.

### Issues
- Missing `parent` property in schemas for `/{area}/{code}` endpoints.
- Wrong `meta.total` property in schemas for `/{area}/{code}` endpoints.
- Missing `meta` property in API responses of `/{area}/{code}` endpoints.

Issue Number: N/A

## What is the new behavior?
This PR fixes the Swagger schema generation so the OpenAPI documentation correctly reflects the actual responses of the API.

We also enable SWC type checking on builds.
